### PR TITLE
sessions: switch to mpi_session_get_nth_psetlen

### DIFF
--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -1713,7 +1713,7 @@ OMPI_DECLSPEC  int MPI_Session_get_info (MPI_Session session, MPI_Info *info_use
 OMPI_DECLSPEC  int MPI_Session_get_num_psets (MPI_Session session, int *npset_names);
 OMPI_DECLSPEC  int MPI_Session_get_nth_pset (MPI_Session session, int n, int len, char *pset_name);
 OMPI_DECLSPEC  int MPI_Session_get_pset_info (MPI_Session session, const char *pset_name, MPI_Info *info_used);
-OMPI_DECLSPEC  int MPI_Session_get_psetlen (MPI_Session session, int n, int *pset_name_len);
+OMPI_DECLSPEC  int MPI_Session_get_nth_psetlen (MPI_Session session, int n, int *pset_len);
 OMPI_DECLSPEC  int MPI_Session_init (MPI_Info info, MPI_Errhandler errhandler,
                                      MPI_Session *session);
 OMPI_DECLSPEC  MPI_Session MPI_Session_f2c (MPI_Fint session);
@@ -2426,7 +2426,7 @@ OMPI_DECLSPEC  int PMPI_Session_get_info (MPI_Session session, MPI_Info *info_us
 OMPI_DECLSPEC  int PMPI_Session_get_num_psets (MPI_Session session, int *npset_names);
 OMPI_DECLSPEC  int PMPI_Session_get_nth_pset (MPI_Session session, int n, int len, char *pset_name);
 OMPI_DECLSPEC  int PMPI_Session_get_pset_info (MPI_Session session, const char *pset_name, MPI_Info *info_used);
-OMPI_DECLSPEC  int PMPI_Session_get_psetlen (MPI_Session session, int n, int *pset_name_len);
+OMPI_DECLSPEC  int PMPI_Session_get_nth_psetlen (MPI_Session session, int n, int *pset_len);
 OMPI_DECLSPEC  int PMPI_Session_init (MPI_Info info, MPI_Errhandler errhandler,
                                      MPI_Session *session);
 OMPI_DECLSPEC  MPI_Session PMPI_Session_f2c (MPI_Fint session);

--- a/ompi/mpi/c/session_get_psetlen.c
+++ b/ompi/mpi/c/session_get_psetlen.c
@@ -18,14 +18,14 @@
 
 #if OMPI_BUILD_MPI_PROFILING
 #if OPAL_HAVE_WEAK_SYMBOLS
-#pragma weak MPI_Session_get_psetlen = PMPI_Session_get_psetlen
+#pragma weak MPI_Session_get_nth_psetlen = PMPI_Session_get_nth_psetlen
 #endif
-#define MPI_Session_get_psetlen PMPI_Session_get_psetlen
+#define MPI_Session_get_nth_psetlen PMPI_Session_get_nth_psetlen
 #endif
 
-static const char FUNC_NAME[] = "MPI_Session_get_psetlen";
+static const char FUNC_NAME[] = "MPI_Session_get_nth_psetlen";
 
-int MPI_Session_get_psetlen (MPI_Session session, int n, int *pset_name_len)
+int MPI_Session_get_nth_psetlen (MPI_Session session, int n, int *pset_name_len)
 {
     int rc;
 


### PR DESCRIPTION
update sessions c interface to current sessions proposal
for getting length of the nth pset name

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>