### PR TITLE
sessions: fortran interfaces

### DIFF
--- a/config/opal_configure_options.m4
+++ b/config/opal_configure_options.m4
@@ -20,6 +20,8 @@ dnl Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
 dnl Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2019      Triad National Security, LLC. All rights
+dnl                         reserved.
 dnl
 dnl $COPYRIGHT$
 dnl
@@ -512,8 +514,9 @@ OPAL_WITH_OPTION_MIN_MAX_VALUE(port_name,      1024, 255, 2048)
 # Min length accroding to MPI-2.1, p. 418
 OPAL_WITH_OPTION_MIN_MAX_VALUE(datarep_string,  128,  64,  256)
 
-# No lower and upper bound required or enforced
 OPAL_WITH_OPTION_MIN_MAX_VALUE(pset_name_len,  512,  512, 4096)
+
+OPAL_WITH_OPTION_MIN_MAX_VALUE(from_group_tag,     1024, 256, 2048)
 
 AC_DEFINE_UNQUOTED([OPAL_ENABLE_CRDEBUG], [0],
     [Whether we want checkpoint/restart enabled debugging functionality or not])

--- a/ompi/include/mpi.h.in
+++ b/ompi/include/mpi.h.in
@@ -20,7 +20,7 @@
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017-2019 IBM Corporation.  All rights reserved.
- * Copyright (c) 2018      Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -99,8 +99,11 @@
 /* Maximum length of processor names (default is 256) */
 #undef OPAL_MAX_PROCESSOR_NAME
 
-/* Maximum length of processor names (default is 256) */
+/* Maximum length of processor names (default is 1024) */
 #undef OPAL_MAX_PSET_NAME_LEN
+
+/* Maximum length of from group tag (default is 256) */
+#undef OPAL_MAX_FROM_GROUP_TAG
 
 /* Whether we have FORTRAN LOGICAL*1 or not */
 #undef OMPI_HAVE_FORTRAN_LOGICAL1
@@ -453,6 +456,7 @@ typedef MPI_Win_errhandler_function MPI_Win_errhandler_fn
 #define MPI_DISTRIBUTE_NONE      2                     /* not distributed */
 #define MPI_DISTRIBUTE_DFLT_DARG (-1)                  /* default distribution arg */
 #define MPI_MAX_PSET_NAME_LEN    OPAL_MAX_PSET_NAME_LEN /* max pset name len */
+#define MPI_MAX_FROM_GROUP_TAG   OPAL_MAX_FROM_GROUP_TAG /* max length of string arg to comm from group funcs*/
 
 /*
  * Since these values are arbitrary to Open MPI, we might as well make

--- a/ompi/include/mpif-config.h.in
+++ b/ompi/include/mpif-config.h.in
@@ -13,6 +13,8 @@
 ! Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved
 ! Copyright (c) 2013      Los Alamos National Security, LLC. All rights
 !                         reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
 ! $COPYRIGHT$
 !
 ! Additional copyrights may follow
@@ -61,6 +63,7 @@
       integer MPI_MAX_PORT_NAME
       integer MPI_MAX_DATAREP_STRING
       integer MPI_MAX_PSET_NAME_LEN
+      integer MPI_MAX_FROM_GROUP_TAG
       parameter (MPI_MAX_PROCESSOR_NAME=@OPAL_MAX_PROCESSOR_NAME@-1)
       parameter (MPI_MAX_ERROR_STRING=@OPAL_MAX_ERROR_STRING@-1)
       parameter (MPI_MAX_OBJECT_NAME=@OPAL_MAX_OBJECT_NAME@-1)
@@ -70,6 +73,7 @@
       parameter (MPI_MAX_PORT_NAME=@OPAL_MAX_PORT_NAME@-1)
       parameter (MPI_MAX_DATAREP_STRING=@OPAL_MAX_DATAREP_STRING@-1)
       parameter (MPI_MAX_PSET_NAME_LEN=@OPAL_MAX_PSET_NAME_LEN@-1)
+      parameter (MPI_MAX_FROM_GROUP_TAG=@OPAL_MAX_FROM_GROUP_TAG@-1)
 
 !
 ! MPI F08 conformance

--- a/ompi/mpi/c/session_get_psetlen.c
+++ b/ompi/mpi/c/session_get_psetlen.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2018      Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *

--- a/ompi/mpi/fortran/mpif-h/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/Makefile.am
@@ -18,6 +18,8 @@
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+# Copyright (c) 2019      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -166,6 +168,7 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         comm_connect_f.c \
         comm_create_errhandler_f.c \
         comm_create_f.c \
+        comm_create_from_group_f.c \
         comm_create_group_f.c \
         comm_create_keyval_f.c \
         comm_delete_attr_f.c \
@@ -287,6 +290,7 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         group_compare_f.c \
         group_difference_f.c \
         group_excl_f.c \
+        group_from_session_pset_f.c \
         group_free_f.c \
         group_incl_f.c \
         group_intersection_f.c \
@@ -328,6 +332,7 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         initialized_f.c \
         init_thread_f.c \
         intercomm_create_f.c \
+        intercomm_from_groups_f.c \
         intercomm_merge_f.c \
         iprobe_f.c \
         irecv_f.c \
@@ -381,6 +386,13 @@ lib@OMPI_LIBMPI_NAME@_mpifh_la_SOURCES += \
         send_init_f.c \
         sendrecv_f.c \
         sendrecv_replace_f.c \
+        session_get_info_f.c \
+        session_get_nth_pset_f.c \
+        session_get_nth_psetlen_f.c \
+        session_get_num_psets_f.c \
+        session_get_pset_info_f.c \
+        session_init_f.c \
+        session_finalize_f.c \
         ssend_f.c \
         ssend_init_f.c \
         startall_f.c \

--- a/ompi/mpi/fortran/mpif-h/comm_create_from_group_f.c
+++ b/ompi/mpi/fortran/mpif-h/comm_create_from_group_f.c
@@ -1,0 +1,116 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/fortran_base_strings.h"
+#include "ompi/constants.h"
+#include "ompi/instance/instance.h"
+
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_COMM_CREATE_FROM_GROUP = ompi_comm_create_from_group_f
+#pragma weak pmpi_comm_create_from_group = ompi_comm_create_from_group_f
+#pragma weak pmpi_comm_create_from_group_ = ompi_comm_create_from_group_f
+#pragma weak pmpi_comm_create_from_group__ = ompi_comm_create_from_group_f
+
+#pragma weak PMPI_Comm_create_from_group_f = ompi_comm_create_from_group_f
+#pragma weak PMPI_Comm_create_from_group_f08 = ompi_comm_create_from_group_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_COMM_CREATE_FROM_GROUP,
+                            pmpi_comm_create_from_group,
+                            pmpi_comm_create_from_group_,
+                            pmpi_comm_create_from_group__,
+                            pmpi_comm_create_from_group_f,
+                            (MPI_Fint *goup, char *stringtag, MPI_Fint *info, MPI_Fint *errhandler, MPI_Fint *newcomm, MPI_Fint *ierr, int name_len),
+                            (group, stringtag, info, errhandler, newcomm, ierr, name_len) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_COMM_CREATE_FROM_GROUP = ompi_comm_create_from_group_f
+#pragma weak mpi_comm_create_from_group = ompi_comm_create_from_group_f
+#pragma weak mpi_comm_create_from_group_ = ompi_comm_create_from_group_f
+#pragma weak mpi_comm_create_from_group__ = ompi_comm_create_from_group_f
+
+#pragma weak MPI_Comm_create_from_group_f = ompi_comm_create_from_group_f
+#pragma weak MPI_Comm_create_from_group_f08 = ompi_comm_create_from_group_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_COMM_CREATE_FROM_GROUP,
+                            mpi_comm_create_from_group,
+                            mpi_comm_create_from_group_,
+                            mpi_comm_create_from_group__,
+                            ompi_comm_create_from_group_f,
+                            (MPI_Fint *goup, char *stringtag, MPI_Fint *info, MPI_Fint *errhandler, MPI_Fint *newcomm, MPI_Fint *ierr, int name_len),
+                            (group, stringtag, info, errhandler, newcomm, ierr, name_len) )
+#else
+#define ompi_comm_create_from_group_f pompi_comm_create_from_group_f
+#endif
+#endif
+
+void ompi_comm_create_from_group_f(MPI_Fint *group, char *stringtag, MPI_Fint *info, MPI_Fint *errhandler, MPI_Fint *newcomm, MPI_Fint *ierr, int name_len)
+{
+    int c_ierr, ret;
+    MPI_Group c_group;
+    char *c_tag;
+    MPI_Comm c_comm;
+    MPI_Info c_info;
+    MPI_Errhandler c_err;
+
+    c_group = PMPI_Group_f2c(*group);
+    c_info = PMPI_Info_f2c(*info);
+    c_err = PMPI_Errhandler_f2c(*errhandler);
+
+    /* Convert the fortran string */
+
+    c_ierr = ompi_fortran_string_f2c(stringtag, name_len, &c_tag);
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+#if 0
+    if (OMPI_SUCCESS != (c = ompi_fortran_string_f2c(stringtag, name_len,
+                                                       &c_tag))) {
+/* TODO - what error handler do we invoke here */
+        c_ierr = OMPI_ERRHANDLER_INVOKE(((ompi_instance_t *)c_group, ret,
+                                        "MPI_COMM_CREATE_FROM_GROUP");
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        return;
+    }
+#endif
+
+    c_ierr = PMPI_Comm_create_from_group(c_group, c_tag, c_info, c_err, &c_comm);
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+    if (MPI_SUCCESS == c_ierr) {
+        *newcomm = PMPI_Comm_c2f (c_comm);
+    }
+
+    /* Free the C tag */
+
+    free(c_tag);
+}
+

--- a/ompi/mpi/fortran/mpif-h/group_from_session_pset_f.c
+++ b/ompi/mpi/fortran/mpif-h/group_from_session_pset_f.c
@@ -1,0 +1,108 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/fortran_base_strings.h"
+#include "ompi/constants.h"
+#include "ompi/instance/instance.h"
+
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_GROUP_FROM_SESSION_PSET = ompi_group_from_session_pset_f
+#pragma weak pmpi_group_from_session_pset = ompi_group_from_session_pset_f
+#pragma weak pmpi_group_from_session_pset_ = ompi_group_from_session_pset_f
+#pragma weak pmpi_group_from_session_pset__ = ompi_group_from_session_pset_f
+
+#pragma weak PMPI_Group_from_session_pset_f = ompi_group_from_session_pset_f
+#pragma weak PMPI_Group_from_session_pset_f08 = ompi_group_from_session_pset_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_GROUP_FROM_SESSION_PSET,
+                            pmpi_group_from_session_pset,
+                            pmpi_group_from_session_pset_,
+                            pmpi_group_from_session_pset__,
+                            pmpi_group_from_session_pset_f,
+                            (MPI_Fint *session, char *pset_name, MPI_Fint *newgroup, MPI_Fint *ierr),
+                            (session, pset_name, newgroup, ierr) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_GROUP_FROM_SESSION_PSET = ompi_group_from_session_pset_f
+#pragma weak mpi_group_from_session_pset = ompi_group_from_session_pset_f
+#pragma weak mpi_group_from_session_pset_ = ompi_group_from_session_pset_f
+#pragma weak mpi_group_from_session_pset__ = ompi_group_from_session_pset_f
+
+#pragma weak MPI_Group_from_session_pset_f = ompi_group_from_session_pset_f
+#pragma weak MPI_Group_from_session_pset_f08 = ompi_group_from_session_pset_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_GROUP_FROM_SESSION_PSET,
+                            mpi_group_from_session_pset,
+                            mpi_group_from_session_pset_,
+                            mpi_group_from_session_pset__,
+                            ompi_group_from_session_pset_f,
+                            (MPI_Fint *session, char *pset_name, MPI_Fint *newgroup, MPI_Fint *ierr),
+                            (session, pset_name, newgroup, ierr) )
+#else
+#define ompi_group_from_session_pset_f pompi_group_from_session_pset_f
+#endif
+#endif
+
+void ompi_group_from_session_pset_f(MPI_Fint *session,char *pset_name, MPI_Fint *newgroup, MPI_Fint *ierr, int name_len)
+{
+    int c_ierr, ret;
+    MPI_Session c_session;
+    char *c_name;
+    MPI_Group c_newgroup;
+
+    c_session = PMPI_Session_f2c(*session);
+
+    /* Convert the fortran string */
+
+    if (OMPI_SUCCESS != (ret = ompi_fortran_string_f2c(pset_name, name_len,
+                                                       &c_name))) {
+        c_ierr = OMPI_ERRHANDLER_INVOKE((ompi_instance_t *)c_session, ret,
+                                        "MPI_GROUP_FROM_SESSION_PSET");
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        return;
+    }
+
+    c_ierr = PMPI_Group_from_session_pset(c_session, c_name, &c_newgroup);
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+    if (MPI_SUCCESS == c_ierr) {
+        *newgroup = PMPI_Group_c2f (c_newgroup);
+    }
+
+    /* Free the C name */
+
+    free(c_name);
+}
+
+

--- a/ompi/mpi/fortran/mpif-h/intercomm_create_from_groups_f.c
+++ b/ompi/mpi/fortran/mpif-h/intercomm_create_from_groups_f.c
@@ -1,0 +1,125 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/fortran_base_strings.h"
+#include "ompi/constants.h"
+#include "ompi/instance/instance.h"
+
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_INTERCOMM_CREATE_FROM_GROUPS = ompi_intercomm_create_from_groups_f
+#pragma weak pmpi_intercomm_create_from_groups = ompi_intercomm_create_from_groups_f
+#pragma weak pmpi_intercomm_create_from_groups_ = ompi_intercomm_create_from_groups_f
+#pragma weak pmpi_intercomm_create_from_groups__ = ompi_intercomm_create_from_groups_f
+
+#pragma weak PMPI_Intercomm_create_from_groups_f = ompi_intercomm_create_from_groups_f
+#pragma weak PMPI_Intercomm_create_from_groups_f08 = ompi_intercomm_create_from_groups_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_INTERCOMM_CREATE_FROM_GROUPS,
+                            pmpi_intercomm_create_from_groups,
+                            pmpi_intercomm_create_from_groups_,
+                            pmpi_intercomm_create_from_groups__,
+                            pmpi_intercomm_create_from_groups_f,
+                            (MPI_Fint *local_group, MPI_Fint *local_leader, MPI_Fint *remote_group,
+                             MPI_Fint *remote_leader, char *stringtag, MPI_Fint *info, MPI_Fint *errhandler,
+                             MPI_Fint *internewcom, MPI_Fint *ierr, int name_len),
+                            (local_group, local_leader, remote_group,
+                             remote_leader, stringtag, info, errhandler, internewcomm, ierr, name_len) )
+
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_INTERCOMM_CREATE_FROM_GROUPS = ompi_intercomm_create_from_groups_f
+#pragma weak mpi_intercomm_create_from_groups = ompi_intercomm_create_from_groups_f
+#pragma weak mpi_intercomm_create_from_groups_ = ompi_intercomm_create_from_groups_f
+#pragma weak mpi_intercomm_create_from_groups__ = ompi_intercomm_create_from_groups_f
+
+#pragma weak MPI_Intercomm_create_from_groups_f = ompi_intercomm_create_from_groups_f
+#pragma weak MPI_Intercomm_create_from_groups_f08 = ompi_intercomm_create_from_groups_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_INTERCOMM_CREATE_FROM_GROUPS,
+                            mpi_intercomm_create_from_groups,
+                            mpi_intercomm_create_from_groups_,
+                            mpi_intercomm_create_from_groups__,
+                            ompi_intercomm_create_from_groups_f,
+                            (MPI_Fint *local_group, MPI_Fint *local_leader, MPI_Fint *remote_group,
+                             MPI_Fint *remote_leader, char *stringtag, MPI_Fint *info, MPI_Fint *errhandler,
+                             MPI_Fint *internewcom, MPI_Fint *ierr, int name_len),
+                            (local_group, local_leader, remote_group,
+                             remote_leader, stringtag, info, errhandler, internewcomm, ierr, name_len) )
+#else
+#define ompi_intercomm_create_from_groups_f pompi_intercomm_create_from_groups_f
+#endif
+#endif
+
+void ompi_intercomm_create_from_groups_f(MPI_Fint *local_group, MPI_Fint *local_leader, MPI_Fint *remote_group,
+                                         MPI_Fint *remote_leader, char *stringtag, MPI_Fint *info, MPI_Fint *errhandler, 
+                                         MPI_Fint *internewcomm, MPI_Fint *ierr, int name_len)
+{
+    int c_ierr, ret;
+    MPI_Group c_lgroup, c_rgroup;
+    char *c_tag;
+    MPI_Comm c_intercomm;
+    MPI_Info c_info;
+    MPI_Errhandler c_err;
+
+    c_lgroup = PMPI_Group_f2c(*local_group);
+    c_rgroup = PMPI_Group_f2c(*remote_group);
+    c_info = PMPI_Info_f2c(*info);
+    c_err = PMPI_Errhandler_f2c(*errhandler);
+
+    /* Convert the fortran string */
+
+    c_ierr = ompi_fortran_string_f2c(stringtag, name_len, &c_tag);
+#if 0
+    if (OMPI_SUCCESS != (ret = ompi_fortran_string_f2c(stringtag, name_len,
+                                                       &c_tag))) {
+        c_ierr = OMPI_ERRHANDLER_INVOKE((ompi_instance_t *)c_session, ret,
+                                        "MPI_INTERCOMM_CREATE_FROM_GROUPS");
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        return;
+    }
+#endif
+
+    c_ierr = PMPI_Intercomm_create_from_groups(c_lgroup,  OMPI_FINT_2_INT(*local_leader), 
+                                               c_rgroup,  OMPI_FINT_2_INT(*remote_leader), 
+                                               c_tag, c_info, c_err, &c_intercomm);
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+    if (MPI_SUCCESS == c_ierr) {
+        *internewcomm = PMPI_Comm_c2f (c_intercomm);
+    }
+
+    /* Free the C tag */
+
+    free(c_tag);
+}

--- a/ompi/mpi/fortran/mpif-h/profile/Makefile.am
+++ b/ompi/mpi/fortran/mpif-h/profile/Makefile.am
@@ -18,6 +18,8 @@
 # Copyright (c) 2015-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+# Copyright (c) 2019      Triad National Security, LLC. All rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -80,6 +82,7 @@ linked_files = \
         pcomm_connect_f.c \
         pcomm_create_errhandler_f.c \
         pcomm_create_f.c \
+        pcomm_create_from_group_f.c \
         pcomm_create_group_f.c \
         pcomm_create_keyval_f.c \
         pcomm_delete_attr_f.c \
@@ -202,6 +205,7 @@ linked_files = \
         pgroup_difference_f.c \
         pgroup_excl_f.c \
         pgroup_free_f.c \
+        pgroup_from_session_pset_f.c \
         pgroup_incl_f.c \
         pgroup_intersection_f.c \
         pgroup_range_excl_f.c \
@@ -242,6 +246,7 @@ linked_files = \
         pinitialized_f.c \
         pinit_thread_f.c \
         pintercomm_create_f.c \
+        pintercomm_create_from_groups_f.c \
         pintercomm_merge_f.c \
         piprobe_f.c \
         pirecv_f.c \
@@ -294,6 +299,13 @@ linked_files = \
         psend_init_f.c \
         psendrecv_f.c \
         psendrecv_replace_f.c \
+        psession_get_info_f.c \
+        psession_get_nth_pset_f.c \
+        psession_get_nth_psetlen_f.c \
+        psession_get_num_psets_f.c \
+        psession_get_pset_info_f.c \
+        psession_init_f.c \
+        psession_finalize_f.c \
         pssend_f.c \
         pssend_init_f.c \
         pstartall_f.c \

--- a/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
+++ b/ompi/mpi/fortran/mpif-h/prototypes_mpi.h
@@ -16,6 +16,8 @@
  *                         reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -124,6 +126,7 @@ PN2(void, MPI_Comm_connect, mpi_comm_connect, MPI_COMM_CONNECT, (char *port_name
 PN2(void, MPI_Comm_create_errhandler, mpi_comm_create_errhandler, MPI_COMM_CREATE_ERRHANDLER, (ompi_errhandler_fortran_handler_fn_t* function, MPI_Fint *errhandler, MPI_Fint *ierr));
 PN2(void, MPI_Comm_create_keyval, mpi_comm_create_keyval, MPI_COMM_CREATE_KEYVAL, (ompi_aint_copy_attr_function* comm_copy_attr_fn, ompi_aint_delete_attr_function* comm_delete_attr_fn, MPI_Fint *comm_keyval, MPI_Aint *extra_state, MPI_Fint *ierr));
 PN2(void, MPI_Comm_create, mpi_comm_create, MPI_COMM_CREATE, (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *newcomm, MPI_Fint *ierr));
+PN2(void, MPI_Comm_create_from_group, mpi_comm_create_from_group, MPI_COMM_CREATE_FROM_GROUP, (MPI_Fint *group, char *stringtag, MPI_Fint *info, MPI_Fint *errhandler, MPI_Fint *newcomm, MPI_Fint *ierr, int name_len));
 PN2(void, MPI_Comm_create_group, mpi_comm_create_group, MPI_COMM_CREATE_GROUP, (MPI_Fint *comm, MPI_Fint *group, MPI_Fint *tag, MPI_Fint *newcomm, MPI_Fint *ierr));
 PN2(void, MPI_Comm_delete_attr, mpi_comm_delete_attr, MPI_COMM_DELETE_ATTR, (MPI_Fint *comm, MPI_Fint *comm_keyval, MPI_Fint *ierr));
 PN2(void, MPI_Comm_disconnect, mpi_comm_disconnect, MPI_COMM_DISCONNECT, (MPI_Fint *comm, MPI_Fint *ierr));
@@ -252,6 +255,7 @@ PN2(void, MPI_Group_compare, mpi_group_compare, MPI_GROUP_COMPARE, (MPI_Fint *gr
 PN2(void, MPI_Group_difference, mpi_group_difference, MPI_GROUP_DIFFERENCE, (MPI_Fint *group1, MPI_Fint *group2, MPI_Fint *newgroup, MPI_Fint *ierr));
 PN2(void, MPI_Group_excl, mpi_group_excl, MPI_GROUP_EXCL, (MPI_Fint *group, MPI_Fint *n, MPI_Fint *ranks, MPI_Fint *newgroup, MPI_Fint *ierr));
 PN2(void, MPI_Group_free, mpi_group_free, MPI_GROUP_FREE, (MPI_Fint *group, MPI_Fint *ierr));
+PN2(void, MPI_Group_from_session_pset, mpi_group_from_session_pset, MPI_GROUP_FROM_SESSION_PSET, (MPI_Fint *group, char *pset_name, MPI_Fint *newgroup, MPI_Fint *ierr, int name_len));
 PN2(void, MPI_Group_incl, mpi_group_incl, MPI_GROUP_INCL, (MPI_Fint *group, MPI_Fint *n, MPI_Fint *ranks, MPI_Fint *newgroup, MPI_Fint *ierr));
 PN2(void, MPI_Group_intersection, mpi_group_intersection, MPI_GROUP_INTERSECTION, (MPI_Fint *group1, MPI_Fint *group2, MPI_Fint *newgroup, MPI_Fint *ierr));
 PN2(void, MPI_Group_range_excl, mpi_group_range_excl, MPI_GROUP_RANGE_EXCL, (MPI_Fint *group, MPI_Fint *n, MPI_Fint ranges[][3], MPI_Fint *newgroup, MPI_Fint *ierr));
@@ -298,6 +302,7 @@ PN2(void, MPI_Init, mpi_init, MPI_INIT, (MPI_Fint *ierr));
 PN2(void, MPI_Initialized, mpi_initialized, MPI_INITIALIZED, (ompi_fortran_logical_t *flag, MPI_Fint *ierr));
 PN2(void, MPI_Init_thread, mpi_init_thread, MPI_INIT_THREAD, (MPI_Fint *required, MPI_Fint *provided, MPI_Fint *ierr));
 PN2(void, MPI_Intercomm_create, mpi_intercomm_create, MPI_INTERCOMM_CREATE, (MPI_Fint *local_comm, MPI_Fint *local_leader, MPI_Fint *bridge_comm, MPI_Fint *remote_leader, MPI_Fint *tag, MPI_Fint *newintercomm, MPI_Fint *ierr));
+PN2(void, MPI_Intercomm_create_from_groups, mpi_intercomm_create_from_groups, MPI_INTERCOMM_CREATE_FROM_GROUPS, (MPI_Fint *local_group, MPI_Fint *local_leader, MPI_Fint *remote_group,  MPI_Fint *remote_leader, char *stringtag, MPI_Fint *info, MPI_Fint *errhandler, MPI_Fint *newintercomm, MPI_Fint *ierr, int name_len));
 PN2(void, MPI_Intercomm_merge, mpi_intercomm_merge, MPI_INTERCOMM_MERGE, (MPI_Fint *intercomm, ompi_fortran_logical_t *high, MPI_Fint *newintercomm, MPI_Fint *ierr));
 PN2(void, MPI_Iprobe, mpi_iprobe, MPI_IPROBE, (MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm, ompi_fortran_logical_t *flag, MPI_Fint *status, MPI_Fint *ierr));
 PN2(void, MPI_Irecv, mpi_irecv, MPI_IRECV, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *source, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
@@ -350,6 +355,13 @@ PN2(void, MPI_Send_init, mpi_send_init, MPI_SEND_INIT, (char *buf, MPI_Fint *cou
 PN2(void, MPI_Send, mpi_send, MPI_SEND, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *ierr));
 PN2(void, MPI_Sendrecv, mpi_sendrecv, MPI_SENDRECV, (char *sendbuf, MPI_Fint *sendcount, MPI_Fint *sendtype, MPI_Fint *dest, MPI_Fint *sendtag, char *recvbuf, MPI_Fint *recvcount, MPI_Fint *recvtype, MPI_Fint *source, MPI_Fint *recvtag, MPI_Fint *comm, MPI_Fint *status, MPI_Fint *ierr));
 PN2(void, MPI_Sendrecv_replace, mpi_sendrecv_replace, MPI_SENDRECV_REPLACE, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *sendtag, MPI_Fint *source, MPI_Fint *recvtag, MPI_Fint *comm, MPI_Fint *status, MPI_Fint *ierr));
+PN2(void, MPI_Session_get_info, mpi_session_get_info, MPI_SESSION_GET_INFO, (MPI_Fint *session, MPI_Fint *info, MPI_Fint *ierr));
+PN2(void, MPI_Session_get_nth_pset, mpi_session_get_nth_pset, MPI_SESSION_GET_NTH_PSET, (MPI_Fint *session, MPI_Fint *n, MPI_Fint *pset_len, char *pset_name, MPI_Fint *ierr));
+PN2(void, MPI_Session_get_nth_psetlen, mpi_session_get_nth_psetlen, MPI_SESSION_GET_NTH_PSETLEN, (MPI_Fint *session, MPI_Fint *n, MPI_Fint *pset_len, MPI_Fint *ierr));
+PN2(void, MPI_Session_get_num_psets, mpi_session_get_num_psets, MPI_SESSION_GET_NUM_PSETS, (MPI_Fint *session, MPI_Fint *npset_names, MPI_Fint *ierr));
+PN2(void, MPI_Session_get_pset_info, mpi_session_get_pset_info, MPI_SESSION_GET_PSET_INFO, (MPI_Fint *session, char *pset_name, MPI_Fint *info, MPI_Fint *ierr, int name_len));
+PN2(void, MPI_Session_init, mpi_session_init, MPI_SESSION_INIT, (MPI_Fint *info, MPI_Fint *errhandler, MPI_Fint *session, MPI_Fint *ierr));
+PN2(void, MPI_Session_finalize, mpi_session_finalize, MPI_SESSION_FINALIZE, (MPI_Fint *session, MPI_Fint *ierr));
 PN2(void, MPI_Ssend_init, mpi_ssend_init, MPI_SSEND_INIT, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *request, MPI_Fint *ierr));
 PN2(void, MPI_Ssend, mpi_ssend, MPI_SSEND, (char *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest, MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *ierr));
 PN2(void, MPI_Start, mpi_start, MPI_START, (MPI_Fint *request, MPI_Fint *ierr));

--- a/ompi/mpi/fortran/mpif-h/session_finalize_f.c
+++ b/ompi/mpi/fortran/mpif-h/session_finalize_f.c
@@ -1,0 +1,83 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_SESSION_FINALIZE = ompi_session_finalize_f
+#pragma weak pmpi_session_finalize = ompi_session_finalize_f
+#pragma weak pmpi_session_finalize_ = ompi_session_finalize_f
+#pragma weak pmpi_session_finalize__ = ompi_session_finalize_f
+
+#pragma weak PMPI_Session_finalize_f = ompi_session_finalize_f
+#pragma weak PMPI_Session_finalize_f08 = ompi_session_finalize_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_SESSION_FINALIZE,
+                            pmpi_session_finalize,
+                            pmpi_session_finalize_,
+                            pmpi_session_finalize__,
+                            pompi_session_finalize_f,
+                            (MPI_Fint *session, MPI_Fint *ierr),
+                            (session, ierr) )
+#endif
+#endif
+
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_SESSION_FINALIZE = ompi_session_finalize_f
+#pragma weak mpi_session_finalize = ompi_session_finalize_f
+#pragma weak mpi_session_finalize_ = ompi_session_finalize_f
+#pragma weak mpi_session_finalize__ = ompi_session_finalize_f
+
+#pragma weak MPI_Session_finalize_f = ompi_session_finalize_f
+#pragma weak MPI_Session_finalize_f08 = ompi_session_finalize_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_SESSION_FINALIZE,
+                            mpi_session_finalize,
+                            mpi_session_finalize_,
+                            mpi_session_finalize__,
+                            ompi_session_finalize_f,
+                            (MPI_Fint *session, MPI_Fint *ierr),
+                            (session, ierr) )
+#else
+#define ompi_session_finalize_f pompi_session_finalize_f
+#endif
+#endif
+
+void ompi_session_finalize_f(MPI_Fint *session, MPI_Fint *ierr)
+{
+    int c_ierr;
+    MPI_Session c_session;
+
+    c_session = PMPI_Session_f2c(*session);
+
+    c_ierr = PMPI_Session_finalize(&c_session);
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+}

--- a/ompi/mpi/fortran/mpif-h/session_get_info_f.c
+++ b/ompi/mpi/fortran/mpif-h/session_get_info_f.c
@@ -1,0 +1,88 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_SESSION_GET_INFO = ompi_session_get_info_f
+#pragma weak pmpi_session_get_info = ompi_session_get_info_f
+#pragma weak pmpi_session_get_info_ = ompi_session_get_info_f
+#pragma weak pmpi_session_get_info__ = ompi_session_get_info_f
+
+#pragma weak PMPI_Session_get_info_f = ompi_session_get_info_f
+#pragma weak PMPI_Session_get_info_f08 = ompi_session_get_info_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_SESSION_GET_INFO,
+                            pmpi_session_get_info,
+                            pmpi_session_get_info_,
+                            pmpi_session_get_info__,
+                            pmpi_session_get_info_f,
+                            (MPI_Fint *session, MPI_Fint *npset_names, MPI_Fint *ierr),
+                            (session, npset_names, ierr) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_SESSION_GET_INFO = ompi_session_get_info_f
+#pragma weak mpi_session_get_info = ompi_session_get_info_f
+#pragma weak mpi_session_get_info_ = ompi_session_get_info_f
+#pragma weak mpi_session_get_info__ = ompi_session_get_info_f
+
+#pragma weak MPI_Session_get_info_f = ompi_session_get_info_f
+#pragma weak MPI_Session_get_info_f08 = ompi_session_get_info_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_SESSION_GET_INFO,
+                            mpi_session_get_info,
+                            mpi_session_get_info_,
+                            mpi_session_get_info__,
+                            ompi_session_get_info_f,
+                            (MPI_Fint *session, MPI_Fint *npset_names, MPI_Fint *ierr),
+                            (session, npset_names, ierr) )
+#else
+#define ompi_session_get_info_f pompi_session_get_info_f
+#endif
+#endif
+
+void ompi_session_get_info_f(MPI_Fint *session, MPI_Fint *info, MPI_Fint *ierr)
+{
+    int c_ierr;
+    MPI_Session c_session;
+    MPI_Info c_info;
+
+    c_session = PMPI_Session_f2c(*session);
+
+    c_ierr = PMPI_Session_get_info(c_session, &c_info);
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+    if (MPI_SUCCESS == c_ierr) {
+        *info = PMPI_Info_c2f(c_info);
+    }
+}

--- a/ompi/mpi/fortran/mpif-h/session_get_nth_pset_f.c
+++ b/ompi/mpi/fortran/mpif-h/session_get_nth_pset_f.c
@@ -1,0 +1,92 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/fortran_base_strings.h"
+#include "ompi/constants.h"
+
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_SESSION_GET_NTH_PSET = ompi_session_get_nth_pset_f
+#pragma weak pmpi_session_get_nth_pset = ompi_session_get_nth_pset_f
+#pragma weak pmpi_session_get_nth_pset_ = ompi_session_get_nth_pset_f
+#pragma weak pmpi_session_get_nth_pset__ = ompi_session_get_nth_pset_f
+
+#pragma weak PMPI_Session_get_nth_pset_f = ompi_session_get_nth_pset_f
+#pragma weak PMPI_Session_get_nth_pset_f08 = ompi_session_get_nth_pset_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_SESSION_GET_NTH_PSET,
+                            pmpi_session_get_nth_pset,
+                            pmpi_session_get_nth_pset_,
+                            pmpi_session_get_nth_pset__,
+                            pmpi_session_get_nth_pset_f,
+                            (MPI_Fint *session, MPI_Fint *npset_names, MPI_Fint *ierr),
+                            (session, npset_names, ierr) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_SESSION_GET_NTH_PSET = ompi_session_get_nth_pset_f
+#pragma weak mpi_session_get_nth_pset = ompi_session_get_nth_pset_f
+#pragma weak mpi_session_get_nth_pset_ = ompi_session_get_nth_pset_f
+#pragma weak mpi_session_get_nth_pset__ = ompi_session_get_nth_pset_f
+
+#pragma weak MPI_Session_get_nth_pset_f = ompi_session_get_nth_pset_f
+#pragma weak MPI_Session_get_nth_pset_f08 = ompi_session_get_nth_pset_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_SESSION_GET_NTH_PSET,
+                            mpi_session_get_nth_pset,
+                            mpi_session_get_nth_pset_,
+                            mpi_session_get_nth_pset__,
+                            ompi_session_get_nth_pset_f,
+                            (MPI_Fint *session, MPI_Fint *npset_names, MPI_Fint *ierr),
+                            (session, npset_names, ierr) )
+#else
+#define ompi_session_get_nth_pset_f pompi_session_get_nth_pset_f
+#endif
+#endif
+
+void ompi_session_get_nth_pset_f(MPI_Fint *session, MPI_Fint *n, MPI_Fint *pset_len, char *pset_name, MPI_Fint *ierr)
+{
+    int c_ierr;
+    MPI_Session c_session;
+    char c_name[MPI_MAX_OBJECT_NAME];
+
+    c_session = PMPI_Session_f2c(*session);
+
+    c_ierr = PMPI_Session_get_nth_pset(c_session, *n,
+                                       MPI_MAX_OBJECT_NAME,
+                                       c_name);
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+    if (MPI_SUCCESS == c_ierr) {
+        ompi_fortran_string_c2f(c_name, pset_name, *pset_len);
+    }
+}

--- a/ompi/mpi/fortran/mpif-h/session_get_nth_psetlen_f.c
+++ b/ompi/mpi/fortran/mpif-h/session_get_nth_psetlen_f.c
@@ -1,0 +1,88 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_SESSION_GET_NTH_PSETLEN = ompi_session_get_nth_psetlen_f
+#pragma weak pmpi_session_get_nth_psetlen = ompi_session_get_nth_psetlen_f
+#pragma weak pmpi_session_get_nth_psetlen_ = ompi_session_get_nth_psetlen_f
+#pragma weak pmpi_session_get_nth_psetlen__ = ompi_session_get_nth_psetlen_f
+
+#pragma weak PMPI_Session_get_nth_psetlen_f = ompi_session_get_nth_psetlen_f
+#pragma weak PMPI_Session_get_nth_psetlen_f08 = ompi_session_get_nth_psetlen_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_SESSION_GET_NTH_PSETLEN,
+                            pmpi_session_get_nth_psetlen,
+                            pmpi_session_get_nth_psetlen_,
+                            pmpi_session_get_nth_psetlen__,
+                            pmpi_session_get_nth_psetlen_f,
+                            (MPI_Fint *session, MPI_Fint *n, MPI_Fint *pset_len, MPI_Fint *ierr),
+                            (session, n, pset_len, ierr) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_SESSION_GET_NTH_PSETLEN = ompi_session_get_nth_psetlen_f
+#pragma weak mpi_session_get_nth_psetlen = ompi_session_get_nth_psetlen_f
+#pragma weak mpi_session_get_nth_psetlen_ = ompi_session_get_nth_psetlen_f
+#pragma weak mpi_session_get_nth_psetlen__ = ompi_session_get_nth_psetlen_f
+
+#pragma weak MPI_Session_get_nth_psetlen_f = ompi_session_get_nth_psetlen_f
+#pragma weak MPI_Session_get_nth_psetlen_f08 = ompi_session_get_nth_psetlen_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_SESSION_GET_NTH_PSETLEN,
+                            mpi_session_get_nth_psetlen,
+                            mpi_session_get_nth_psetlen_,
+                            mpi_session_get_nth_psetlen__,
+                            ompi_session_get_nth_psetlen_f,
+                            (MPI_Fint *session, MPI_Fint *n, MPI_Fint *pset_len, MPI_Fint *ierr),
+                            (session, n, npset_len, ierr) )
+#else
+#define ompi_session_get_nth_psetlen_f pompi_session_get_nth_psetlen_f
+#endif
+#endif
+
+void ompi_session_get_nth_psetlen_f(MPI_Fint *session, MPI_Fint *n, MPI_Fint *pset_len, MPI_Fint *ierr)
+{
+    int c_ierr;
+    MPI_Session c_session;
+    OMPI_SINGLE_NAME_DECL(pset_len);
+    OMPI_SINGLE_NAME_DECL(n);
+
+    c_session = PMPI_Session_f2c(*session);
+
+    c_ierr = PMPI_Session_get_nth_psetlen(c_session, OMPI_SINGLE_NAME_CONVERT(n), OMPI_SINGLE_NAME_CONVERT(pset_len));
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+    if (MPI_SUCCESS == c_ierr) {
+        OMPI_SINGLE_INT_2_FINT(npset_len);
+    }
+}

--- a/ompi/mpi/fortran/mpif-h/session_get_num_psets_f.c
+++ b/ompi/mpi/fortran/mpif-h/session_get_num_psets_f.c
@@ -1,0 +1,87 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_SESSION_GET_NUM_PSETS = ompi_session_get_num_psets_f
+#pragma weak pmpi_session_get_num_psets = ompi_session_get_num_psets_f
+#pragma weak pmpi_session_get_num_psets_ = ompi_session_get_num_psets_f
+#pragma weak pmpi_session_get_num_psets__ = ompi_session_get_num_psets_f
+
+#pragma weak PMPI_Session_get_num_psets_f = ompi_session_get_num_psets_f
+#pragma weak PMPI_Session_get_num_psets_f08 = ompi_session_get_num_psets_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_SESSION_GET_NUM_PSETS,
+                            pmpi_session_get_num_psets,
+                            pmpi_session_get_num_psets_,
+                            pmpi_session_get_num_psets__,
+                            pmpi_session_get_num_psets_f,
+                            (MPI_Fint *session, MPI_Fint *npset_names, MPI_Fint *ierr),
+                            (session, npset_names, ierr) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_SESSION_GET_NUM_PSETS = ompi_session_get_num_psets_f
+#pragma weak mpi_session_get_num_psets = ompi_session_get_num_psets_f
+#pragma weak mpi_session_get_num_psets_ = ompi_session_get_num_psets_f
+#pragma weak mpi_session_get_num_psets__ = ompi_session_get_num_psets_f
+
+#pragma weak MPI_Session_get_num_psets_f = ompi_session_get_num_psets_f
+#pragma weak MPI_Session_get_num_psets_f08 = ompi_session_get_num_psets_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_SESSION_GET_NUM_PSETS,
+                            mpi_session_get_num_psets,
+                            mpi_session_get_num_psets_,
+                            mpi_session_get_num_psets__,
+                            ompi_session_get_num_psets_f,
+                            (MPI_Fint *session, MPI_Fint *npset_names, MPI_Fint *ierr),
+                            (session, npset_names, ierr) )
+#else
+#define ompi_session_get_num_psets_f pompi_session_get_num_psets_f
+#endif
+#endif
+
+void ompi_session_get_num_psets_f(MPI_Fint *session, MPI_Fint *npset_names, MPI_Fint *ierr)
+{
+    int c_ierr;
+    MPI_Session c_session;
+    OMPI_SINGLE_NAME_DECL(npset_names);
+
+    c_session = PMPI_Session_f2c(*session);
+
+    c_ierr = PMPI_Session_get_num_psets(c_session, OMPI_SINGLE_NAME_CONVERT(npset_names));
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+    if (MPI_SUCCESS == c_ierr) {
+        OMPI_SINGLE_INT_2_FINT(npset_names);
+    }
+}

--- a/ompi/mpi/fortran/mpif-h/session_get_pset_info_f.c
+++ b/ompi/mpi/fortran/mpif-h/session_get_pset_info_f.c
@@ -1,0 +1,104 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+#include "ompi/mpi/fortran/base/fortran_base_strings.h"
+#include "ompi/constants.h"
+#include "ompi/instance/instance.h"
+
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_SESSION_GET_PSET_INFO = ompi_session_get_pset_info_f
+#pragma weak pmpi_session_get_pset_info = ompi_session_get_pset_info_f
+#pragma weak pmpi_session_get_pset_info_ = ompi_session_get_pset_info_f
+#pragma weak pmpi_session_get_pset_info__ = ompi_session_get_pset_info_f
+
+#pragma weak PMPI_Session_get_pset_info_f = ompi_session_get_pset_info_f
+#pragma weak PMPI_Session_get_pset_info_f08 = ompi_session_get_pset_info_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_SESSION_GET_PSET_INFO,
+                            pmpi_session_get_pset_info,
+                            pmpi_session_get_pset_info_,
+                            pmpi_session_get_pset_info__,
+                            pmpi_session_get_pset_info_f,
+                            (MPI_Fint *session, char *pset_name, MPI_Fint *info, MPI_Fint *ierr, int name_len),
+                            (session, pset_name, info, ierr, name_len) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_SESSION_GET_PSET_INFO = ompi_session_get_pset_info_f
+#pragma weak mpi_session_get_pset_info = ompi_session_get_pset_info_f
+#pragma weak mpi_session_get_pset_info_ = ompi_session_get_pset_info_f
+#pragma weak mpi_session_get_pset_info__ = ompi_session_get_pset_info_f
+
+#pragma weak MPI_Session_get_pset_info_f = ompi_session_get_pset_info_f
+#pragma weak MPI_Session_get_pset_info_f08 = ompi_session_get_pset_info_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_SESSION_GET_PSET_INFO,
+                            mpi_session_get_pset_info,
+                            mpi_session_get_pset_info_,
+                            mpi_session_get_pset_info__,
+                            ompi_session_get_pset_info_f,
+                            (MPI_Fint *session, char *pset_name, MPI_Fint *info, MPI_Fint *ierr, int name_len),
+                            (session, pset_name, info, ierr, name_len) )
+#else
+#define ompi_session_get_pset_info_f pompi_session_get_pset_info_f
+#endif
+#endif
+
+void ompi_session_get_pset_info_f(MPI_Fint *session,char *pset_name, MPI_Fint *info, MPI_Fint *ierr, int name_len)
+{
+    int c_ierr, ret;
+    MPI_Session c_session;
+    char *c_name;
+    MPI_Info c_info;
+
+    c_session = PMPI_Session_f2c(*session);
+
+    /* Convert the fortran string */
+
+    if (OMPI_SUCCESS != (ret = ompi_fortran_string_f2c(pset_name, name_len,
+                                                       &c_name))) {
+        c_ierr = OMPI_ERRHANDLER_INVOKE((ompi_instance_t *)c_session, ret,
+                                        "MPI_SESSION_GET_PSET_INFO");
+        if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+        return;
+    }
+
+    c_ierr = PMPI_Session_get_pset_info(c_session, c_name, &c_info);
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+    if (MPI_SUCCESS == c_ierr) {
+        *info = PMPI_Info_c2f(c_info);
+    }
+}
+
+

--- a/ompi/mpi/fortran/mpif-h/session_init_f.c
+++ b/ompi/mpi/fortran/mpif-h/session_init_f.c
@@ -1,0 +1,89 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "ompi_config.h"
+
+#include "ompi/mpi/fortran/mpif-h/bindings.h"
+
+#if OMPI_BUILD_MPI_PROFILING
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak PMPI_SESSION_INIT = ompi_session_init_f
+#pragma weak pmpi_session_init = ompi_session_init_f
+#pragma weak pmpi_session_init_ = ompi_session_init_f
+#pragma weak pmpi_session_init__ = ompi_session_init_f
+
+#pragma weak PMPI_Session_init_f = ompi_session_init_f
+#pragma weak PMPI_Session_init_f08 = ompi_session_init_f
+#else
+OMPI_GENERATE_F77_BINDINGS (PMPI_SESSION_INIT,
+                            pmpi_session_init,
+                            pmpi_session_init_,
+                            pmpi_session_init__,
+                            pompi_session_init_f,
+                            (MPI_Fint *info, MPI_Fint *errhandler, MPI_Fint *session, MPI_Fint *ierr),
+                            (info, errhandler, session, ierr) )
+#endif
+#endif
+
+#if OPAL_HAVE_WEAK_SYMBOLS
+#pragma weak MPI_SESSION_INIT = ompi_session_init_f
+#pragma weak mpi_session_init = ompi_session_init_f
+#pragma weak mpi_session_init_ = ompi_session_init_f
+#pragma weak mpi_session_init__ = ompi_session_init_f
+
+#pragma weak MPI_Session_init_f = ompi_session_init_f
+#pragma weak MPI_Session_init_f08 = ompi_session_init_f
+#else
+#if ! OMPI_BUILD_MPI_PROFILING
+OMPI_GENERATE_F77_BINDINGS (MPI_SESSION_INIT,
+                            mpi_session_init,
+                            mpi_session_init_,
+                            mpi_session_init__,
+                            ompi_session_init_f,
+                            (MPI_Fint *info, MPI_Fint *errhandler, MPI_Fint *session, MPI_Fint *ierr),
+                            (info, errhandler, session, ierr) )
+#else
+#define ompi_session_init_f pompi_session_init_f
+#endif
+#endif
+
+void ompi_session_init_f(MPI_Fint *info, MPI_Fint *errhandler, MPI_Fint *session, MPI_Fint *ierr)
+{
+    int c_ierr;
+    MPI_Session c_session;
+    MPI_Info c_info;
+    MPI_Errhandler c_errhandler;
+
+    c_info = PMPI_Info_f2c(*info);
+    c_errhandler = PMPI_Errhandler_f2c(*errhandler);
+
+    c_ierr = PMPI_Session_init(c_info, c_errhandler, &c_session);
+    if (NULL != ierr) *ierr = OMPI_INT_2_FINT(c_ierr);
+
+    if (MPI_SUCCESS == c_ierr) {
+        *session = PMPI_Session_c2f(c_session);
+    }
+}

--- a/ompi/mpi/fortran/use-mpi-f08/Makefile.am
+++ b/ompi/mpi/fortran/use-mpi-f08/Makefile.am
@@ -130,6 +130,7 @@ mpi_api_files = \
         comm_connect_f08.F90 \
         comm_create_errhandler_f08.F90 \
         comm_create_f08.F90 \
+        comm_create_from_group_f08.F90 \
         comm_create_group_f08.F90 \
         comm_create_keyval_f08.F90 \
         comm_delete_attr_f08.F90 \
@@ -256,6 +257,7 @@ mpi_api_files = \
         group_difference_f08.F90 \
         group_excl_f08.F90 \
         group_free_f08.F90 \
+        group_from_session_pset_f08.F90 \
         group_incl_f08.F90 \
         group_intersection_f08.F90 \
         group_range_excl_f08.F90 \
@@ -296,6 +298,7 @@ mpi_api_files = \
         initialized_f08.F90 \
         init_thread_f08.F90 \
         intercomm_create_f08.F90 \
+        intercomm_create_from_groups_f08.F90 \
         intercomm_merge_f08.F90 \
         iprobe_f08.F90 \
         irecv_f08.F90 \
@@ -352,6 +355,13 @@ mpi_api_files = \
         send_init_f08.F90 \
         sendrecv_f08.F90 \
         sendrecv_replace_f08.F90 \
+	session_get_info_f08.F90 \
+	session_get_nth_pset_f08.F90 \
+	session_get_nth_psetlen_f08.F90 \
+	session_get_num_psets_f08.F90 \
+	session_get_pset_info_f08.F90 \
+	session_init_f08.F90 \
+	session_finalize_f08.F90 \
         ssend_f08.F90 \
         ssend_init_f08.F90 \
         startall_f08.F90 \
@@ -485,6 +495,7 @@ pmpi_api_files = \
         profile/pcomm_connect_f08.F90 \
         profile/pcomm_create_errhandler_f08.F90 \
         profile/pcomm_create_f08.F90 \
+        profile/pcomm_create_from_group_f08.F90 \
         profile/pcomm_create_group_f08.F90 \
         profile/pcomm_create_keyval_f08.F90 \
         profile/pcomm_delete_attr_f08.F90 \
@@ -611,6 +622,7 @@ pmpi_api_files = \
         profile/pgroup_difference_f08.F90 \
         profile/pgroup_excl_f08.F90 \
         profile/pgroup_free_f08.F90 \
+        profile/pgroup_from_session_pset_f08.F90 \
         profile/pgroup_incl_f08.F90 \
         profile/pgroup_intersection_f08.F90 \
         profile/pgroup_range_excl_f08.F90 \
@@ -651,6 +663,7 @@ pmpi_api_files = \
         profile/pinitialized_f08.F90 \
         profile/pinit_thread_f08.F90 \
         profile/pintercomm_create_f08.F90 \
+        profile/pintercomm_create_from_groups_f08.F90 \
         profile/pintercomm_merge_f08.F90 \
         profile/piprobe_f08.F90 \
         profile/pirecv_f08.F90 \
@@ -707,6 +720,13 @@ pmpi_api_files = \
         profile/psend_init_f08.F90 \
         profile/psendrecv_f08.F90 \
         profile/psendrecv_replace_f08.F90 \
+	profile/psession_get_info_f08.F90 \
+	profile/psession_get_nth_pset_f08.F90 \
+	profile/psession_get_nth_psetlen_f08.F90 \
+	profile/psession_get_num_psets_f08.F90 \
+	profile/psession_get_pset_info_f08.F90 \
+	profile/psession_init_f08.F90 \
+	profile/psession_finalize_f08.F90 \
         profile/pssend_f08.F90 \
         profile/pssend_init_f08.F90 \
         profile/pstartall_f08.F90 \

--- a/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
+++ b/ompi/mpi/fortran/use-mpi-f08/bindings/mpi-f-interfaces-bind.h
@@ -9,6 +9,8 @@
 ! Copyright (c) 2012      Inria.  All rights reserved.
 ! Copyright (c) 2015-2018 Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
 ! $COPYRIGHT$
 !
 ! This file provides the interface specifications for the MPI Fortran
@@ -1269,6 +1271,19 @@ subroutine ompi_comm_create_f(comm,group,newcomm,ierror) &
    INTEGER, INTENT(OUT) :: ierror
 end subroutine ompi_comm_create_f
 
+subroutine ompi_comm_create_from_group_f(group, stringtag, info, errhandler, newcomm, ierror, name_len) &
+   BIND(C, name="ompi_comm_create_from_group_f")
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   implicit none
+   integer, intent(in) :: group
+   CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: stringtag
+   integer, intent(in) :: info
+   integer, intent(in) :: errhandler
+   integer, intent(out) :: newcomm
+   integer, intent(out) :: ierror
+   INTEGER, VALUE, INTENT(IN) :: name_len
+end subroutine ompi_comm_create_from_group_f
+
 subroutine ompi_comm_create_group_f(comm, group, tag, newcomm, ierror) &
    BIND(C, name="ompi_comm_create_group_f")
    implicit none
@@ -1349,6 +1364,19 @@ subroutine ompi_comm_get_name_f(comm,comm_name,resultlen,ierror,comm_name_len) &
    INTEGER, INTENT(OUT) :: ierror
    INTEGER, VALUE, INTENT(IN) :: comm_name_len
 end subroutine ompi_comm_get_name_f
+
+subroutine ompi_comm_from_group_f(group, stringtag, info, errhandler, newcomm, ierror, name_len) &
+   BIND(C, name="ompi_comm_from_group_f")
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   implicit none
+   INTEGER, INTENT(IN) :: group
+   CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: stringtag
+   INTEGER, INTENT(IN) :: info
+   INTEGER, INTENT(IN) :: errhandler
+   INTEGER, INTENT(OUT) :: newcomm
+   INTEGER, INTENT(OUT) :: ierror
+   INTEGER, VALUE, INTENT(IN) :: name_len
+end subroutine ompi_comm_from_group_f
 
 subroutine ompi_comm_group_f(comm,group,ierror) &
    BIND(C, name="ompi_comm_group_f")
@@ -1471,6 +1499,17 @@ subroutine ompi_group_free_f(group,ierror) &
    INTEGER, INTENT(OUT) :: ierror
 end subroutine ompi_group_free_f
 
+subroutine ompi_group_from_session_pset_f(session, pset_name, newgroup, ierror, name_len) &
+   BIND(C, name="ompi_group_from_session_pset_f")
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   implicit none
+   INTEGER, INTENT(IN) :: session
+   CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: pset_name
+   INTEGER, INTENT(OUT) :: newgroup
+   integer, intent(out) :: ierror
+   INTEGER, VALUE, INTENT(IN) :: name_len
+end subroutine ompi_group_from_session_pset_f
+
 subroutine ompi_group_incl_f(group,n,ranks,newgroup,ierror) &
    BIND(C, name="ompi_group_incl_f")
    implicit none
@@ -1553,6 +1592,21 @@ subroutine ompi_intercomm_create_f(local_comm,local_leader,peer_comm, &
    INTEGER, INTENT(OUT) :: newintercomm
    INTEGER, INTENT(OUT) :: ierror
 end subroutine ompi_intercomm_create_f
+
+subroutine ompi_intercomm_create_from_groups_f(local_group, local_leader, remote_group,  &
+                                               remote_leader, stringtag, info, errhandler, &
+                                               newintercomm, ierror, name_len) &
+   BIND(C, name="ompi_intercomm_create_from_groups_f")
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   implicit none
+   INTEGER, INTENT(IN) :: local_group, remote_group
+   INTEGER, INTENT(IN) :: local_leader, remote_leader
+   CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: stringtag
+   INTEGER, INTENT(IN) :: info, errhandler
+   INTEGER, INTENT(OUT) :: newintercomm
+   INTEGER, INTENT(OUT) :: ierror
+   INTEGER, VALUE, INTENT(IN) :: name_len
+end subroutine ompi_intercomm_create_from_groups_f
 
 subroutine ompi_type_create_keyval_f(type_copy_attr_fn,type_delete_attr_fn, &
                                      type_keyval,extra_state,ierror) &
@@ -3495,5 +3549,68 @@ subroutine ompi_ineighbor_alltoallw_f(sendbuf,sendcounts,sdispls,sendtypes,recvb
    INTEGER, INTENT(OUT) :: request
    INTEGER, INTENT(OUT) :: ierror
 end subroutine ompi_ineighbor_alltoallw_f
+
+subroutine ompi_session_get_info_f(session, info, ierror) &
+   BIND(C, name="ompi_session_get_info_f")
+   implicit none
+   integer, intent(in) :: session
+   integer, intent(out) :: info
+   integer, intent(out) :: ierror
+end subroutine ompi_session_get_info_f
+
+subroutine ompi_session_get_nth_pset_f(session, n, pset_len, pset_name, ierror) &
+   BIND(C, name="ompi_session_get_nth_pset_f")
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   implicit none
+   integer, intent(in) :: session
+   integer, intent(in) :: n
+   integer, intent(in) :: pset_len
+   CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(OUT) :: pset_name
+   integer, intent(out) :: ierror
+end subroutine ompi_session_get_nth_pset_f
+
+subroutine ompi_session_get_nth_psetlen_f(session, n, pset_len, ierror) &
+   BIND(C, name="ompi_session_get_nth_psetlen_f")
+  implicit none
+  integer, intent(in) :: session
+  integer, intent(in) :: n
+  integer, intent(out) :: pset_len
+  integer, intent(out) :: ierror
+end subroutine ompi_session_get_nth_psetlen_f
+
+subroutine ompi_session_get_num_psets_f(session, npset_names, ierror) &
+   BIND(C, name="ompi_session_get_num_psets_f")
+  implicit none
+  integer, intent(in) :: session
+  integer, intent(out) :: npset_names
+  integer, intent(out) :: ierror
+end subroutine ompi_session_get_num_psets_f
+
+subroutine ompi_session_get_pset_info_f(session, pset_name, info, ierror, name_len) &
+   BIND(C, name="ompi_session_get_pset_info_f")
+   use, intrinsic :: ISO_C_BINDING, only : C_CHAR
+   implicit none
+   integer, intent(in) :: session
+   CHARACTER(KIND=C_CHAR), DIMENSION(*), INTENT(IN) :: pset_name
+   INTEGER, VALUE, INTENT(IN) :: name_len
+   integer, intent(out) :: info
+   integer, intent(out) :: ierror
+end subroutine ompi_session_get_pset_info_f
+
+subroutine ompi_session_init_f(info, errhandler, session, ierror) &
+   BIND(C, name="ompi_session_init_f")
+  implicit none
+  integer, intent(in) :: info
+  integer, intent(in) :: errhandler
+  integer, intent(out) :: session
+  integer, intent(out) :: ierror
+end subroutine ompi_session_init_f
+
+subroutine ompi_session_finalize_f(session, ierror) &
+   BIND(C, name="ompi_session_finalize_f")
+  implicit none
+  integer, intent(out) :: session
+  integer, intent(out) :: ierror
+end subroutine ompi_session_finalize_f
 
 end interface

--- a/ompi/mpi/fortran/use-mpi-f08/comm_create_from_group_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/comm_create_from_group_f08.F90
@@ -1,0 +1,29 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine MPI_Comm_create_from_group_f08(group, stringtag, info, errhandler, newcomm, ierror)
+   use :: mpi_f08_types, only : MPI_Comm, MPI_Group, MPI_Errhandler, MPI_Info
+   use :: ompi_mpifh_bindings, only : ompi_comm_create_from_group_f
+   implicit none
+   TYPE(MPI_Group), INTENT(IN) :: group
+   CHARACTER(LEN=*), INTENT(IN) :: stringtag
+   TYPE(MPI_Info), INTENT(IN) :: info
+   TYPE(MPI_Errhandler), INTENT(IN) :: errhandler
+   TYPE(MPI_Comm), INTENT(OUT) :: newcomm
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_create_comm_from_group_f(group%MPI_VAL, stringtag, info%MPI_VAL, errhandler%MPI_VAL, &
+                                      newcomm%MPI_VAL, c_ierror, len(stringtag))
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Comm_create_from_group_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/comm_get_name_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/comm_get_name_f08.F90
@@ -17,7 +17,8 @@ subroutine MPI_Comm_get_name_f08(comm,comm_name,resultlen,ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
    integer :: c_ierror
 
-   call ompi_comm_get_name_f(comm%MPI_VAL,comm_name,resultlen,c_ierror,len(comm_name))
+   call ompi_comm_get_name_f(comm%MPI_VAL,comm_name,resultlen,c_ierror, &
+                             len(comm_name))
    if (present(ierror)) ierror = c_ierror
 
 end subroutine MPI_Comm_get_name_f08

--- a/ompi/mpi/fortran/use-mpi-f08/group_from_session_pset_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/group_from_session_pset_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine MPI_Group_from_session_pset_f08(session, pset_name, newgroup, ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Group
+   use :: ompi_mpifh_bindings, only : ompi_group_from_session_pset_f
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   CHARACTER(LEN=*), INTENT(IN) :: pset_name
+   TYPE(MPI_Group), INTENT(OUT) :: newgroup
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_group_from_session_pset_f(session%MPI_VAL, pset_name, newgroup%MPI_VAL, c_ierror, len(pset_name))
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Group_from_session_pset_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/intercomm_create_from_groups_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/intercomm_create_from_groups_f08.F90
@@ -1,0 +1,35 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine MPI_Intercomm_create_from_groups_f08(local_group, local_leader, remote_group, &
+                                                remote_leader, stringtag, info, errhandler, &
+                                                newintercomm, ierror)
+   use :: mpi_f08_types, only : MPI_Comm, MPI_Group, MPI_Errhandler, MPI_Info
+   use :: ompi_mpifh_bindings, only : ompi_intercomm_create_from_groups_f
+   implicit none
+   TYPE(MPI_Group), INTENT(IN) :: local_group, remote_group
+   INTEGER, INTENT(IN):: local_leader, remote_leader
+   CHARACTER(LEN=*), INTENT(IN) :: stringtag
+   TYPE(MPI_Info), INTENT(IN) :: info
+   TYPE(MPI_Errhandler), INTENT(IN) :: errhandler
+   TYPE(MPI_Comm), INTENT(OUT) :: newintercomm
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_create_intercomm_from_groups_f(local_group%MPI_VAL, local_leader, &
+                                            remote_group%MPI_VAL,  &
+                                            remote_leader, stringtag, info%MPI_VAL, &
+                                            errhandler%MPI_VAL, &
+                                            newintercomm%MPI_VAL, c_ierror, len(stringtag))
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Intercomm_create_from_groups_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-interfaces.F90
@@ -10,6 +10,8 @@
 ! Copyright (c) 2015-2017 Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
 ! Copyright (c) 2017-2018 FUJITSU LIMITED.  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
 ! $COPYRIGHT$
 !
 ! This file provides the interface specifications for the MPI Fortran
@@ -377,6 +379,80 @@ subroutine MPI_Send_init_f08(buf,count,datatype,dest,tag,comm,request,ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine MPI_Send_init_f08
 end interface  MPI_Send_init
+
+interface MPI_Session_get_info
+subroutine MPI_Session_get_info_f08(session, info, ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Info
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   TYPE(MPI_Info), INTENT(OUT) :: info
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine MPI_Session_get_info_f08
+end interface MPI_Session_get_info
+
+interface MPI_Session_get_nth_pset
+subroutine MPI_Session_get_nth_pset_f08(session, n, pset_len, pset_name, ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   INTEGER, INTENT(IN) :: n
+   INTEGER, INTENT(IN) :: pset_len
+   CHARACTER(LEN=*), INTENT(OUT) :: pset_name
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine MPI_Session_get_nth_pset_f08
+end interface MPI_Session_get_nth_pset
+
+interface MPI_Session_get_nth_psetlen
+subroutine MPI_Session_get_nth_psetlen_f08(session, n, pset_len, ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   INTEGER, INTENT(IN) :: n
+   INTEGER, INTENT(OUT) :: pset_len
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine MPI_Session_get_nth_psetlen_f08
+end interface MPI_Session_get_nth_psetlen
+
+interface MPI_Session_get_num_psets
+subroutine MPI_Session_get_num_psets_f08(session, npset_names, ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   INTEGER, INTENT(OUT) :: npset_names
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine MPI_Session_get_num_psets_f08
+end interface  MPI_Session_get_num_psets
+
+interface MPI_Session_get_pset_info
+subroutine MPI_Session_get_pset_info_f08(session, pset_name, info, ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Info
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   CHARACTER(LEN=*), INTENT(IN) :: pset_name
+   TYPE(MPI_Info), INTENT(OUT) :: info
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine MPI_Session_get_pset_info_f08
+end interface MPI_Session_get_pset_info
+
+interface  MPI_Session_init
+subroutine MPI_Session_init_f08(info,errhandler,session,ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Info, MPI_Errhandler
+   implicit none
+   TYPE(MPI_Info), INTENT(IN) :: info
+   TYPE(MPI_Errhandler), INTENT(OUT) :: errhandler
+   TYPE(MPI_Session), INTENT(OUT) :: session
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine MPI_Session_init_f08
+end interface  MPI_Session_init
+
+interface  MPI_Session_finalize
+subroutine MPI_Session_finalize_f08(session,ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   implicit none
+   TYPE(MPI_Session), INTENT(INOUT) :: session
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine MPI_Session_finalize_f08
+end interface  MPI_Session_finalize
 
 interface  MPI_Ssend
 subroutine MPI_Ssend_f08(buf,count,datatype,dest,tag,comm,ierror)
@@ -1656,6 +1732,20 @@ subroutine MPI_Comm_create_f08(comm,group,newcomm,ierror)
 end subroutine MPI_Comm_create_f08
 end interface  MPI_Comm_create
 
+interface  MPI_Comm_create_from_group
+subroutine MPI_Comm_create_from_group_f08(group, stringtag, info, errhandler, newcomm, ierror)
+   use :: mpi_f08_types, only : MPI_Comm, MPI_Group, MPI_Info, MPI_Errhandler
+   implicit none
+   TYPE(MPI_Group), INTENT(IN) :: group
+   CHARACTER(LEN=*), INTENT(IN) :: stringtag
+   TYPE(MPI_Info), INTENT(IN) :: info
+   TYPE(MPI_Errhandler), INTENT(IN) :: errhandler
+   TYPE(MPI_Comm), INTENT(OUT) :: newcomm
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+
+end subroutine MPI_Comm_create_from_group_f08
+end interface  MPI_Comm_create_from_group
+
 interface  MPI_Comm_create_group
 subroutine MPI_Comm_create_group_f08(comm,group,tag,newcomm,ierror)
    use :: mpi_f08_types, only : MPI_Comm, MPI_Group
@@ -1917,6 +2007,17 @@ subroutine MPI_Group_free_f08(group,ierror)
 end subroutine MPI_Group_free_f08
 end interface  MPI_Group_free
 
+interface MPI_Group_from_session_pset
+subroutine MPI_Group_from_session_pset_f08(session, pset_name, newgroup, ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Group
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   CHARACTER(LEN=*), INTENT(IN) :: pset_name
+   TYPE(MPI_Group), INTENT(OUT) :: newgroup
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine MPI_Group_from_session_pset_f08
+end interface MPI_Group_from_session_pset
+
 interface  MPI_Group_incl
 subroutine MPI_Group_incl_f08(group,n,ranks,newgroup,ierror)
    use :: mpi_f08_types, only : MPI_Group
@@ -2013,6 +2114,21 @@ subroutine MPI_Intercomm_create_f08(local_comm,local_leader,peer_comm,remote_lea
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine MPI_Intercomm_create_f08
 end interface  MPI_Intercomm_create
+
+interface MPI_Intercomm_create_from_groups
+subroutine MPI_Intercomm_create_from_groups_f08(local_group, local_leader, remote_group, remote_leader, &
+                                          stringtag, info, errhandler, newintercomm, ierror)
+   use :: mpi_f08_types, only : MPI_Comm, MPI_Group, MPI_Errhandler, MPI_Info
+   implicit none
+   TYPE(MPI_Group), INTENT(IN) :: local_group, remote_group
+   INTEGER, INTENT(IN):: local_leader, remote_leader
+   CHARACTER(LEN=*), INTENT(IN) :: stringtag
+   TYPE(MPI_Info), INTENT(IN) :: info
+   TYPE(MPI_Errhandler), INTENT(IN) :: errhandler
+   TYPE(MPI_Comm), INTENT(OUT) :: newintercomm
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine MPI_Intercomm_create_from_groups_f08
+end interface MPI_Intercomm_create_from_groups
 
 interface  MPI_Intercomm_merge
 subroutine MPI_Intercomm_merge_f08(intercomm,high,newintracomm,ierror)

--- a/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/mpi-f08-types.F90
@@ -6,6 +6,8 @@
 ! Copyright (c) 2015-2018 Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
 ! Copyright (c) 2018      FUJITSU LIMITED.  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
 ! $COPYRIGHT$
 !
 ! This file creates mappings between MPI C types (e.g., MPI_Comm) and
@@ -65,6 +67,10 @@ module mpi_f08_types
    type, BIND(C) :: MPI_Win
       integer :: MPI_VAL
    end type MPI_Win
+
+   type, BIND(C) :: MPI_Session
+      integer :: MPI_VAL
+   end type MPI_Session
 
    type, BIND(C) :: MPI_Status
       integer :: MPI_SOURCE

--- a/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/mod/pmpi-f08-interfaces.F90
@@ -10,6 +10,8 @@
 ! Copyright (c) 2015-2017 Research Organization for Information Science
 !                         and Technology (RIST). All rights reserved.
 ! Copyright (c) 2017-2018 FUJITSU LIMITED.  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
 ! $COPYRIGHT$
 !
 ! This file provides the interface specifications for the MPI Fortran
@@ -377,6 +379,47 @@ subroutine PMPI_Send_init_f08(buf,count,datatype,dest,tag,comm,request,ierror)
    INTEGER, OPTIONAL, INTENT(OUT) :: ierror
 end subroutine PMPI_Send_init_f08
 end interface  PMPI_Send_init
+
+interface PMPI_Session_get_nth_psetlen
+subroutine PMPI_Session_get_nth_psetlen_f08(session, n, pset_len, ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   INTEGER, OPTIONAL, INTENT(IN) :: n
+   INTEGER, OPTIONAL, INTENT(OUT) :: pset_len
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Session_get_nth_psetlen_f08
+end interface PMPI_Session_get_nth_psetlen
+
+interface PMPI_Session_get_num_psets
+subroutine PMPI_Session_get_num_psets_f08(session, npset_names, ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   INTEGER, OPTIONAL, INTENT(OUT) :: npset_names
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Session_get_num_psets_f08
+end interface  PMPI_Session_get_num_psets
+
+interface  PMPI_Session_init
+subroutine PMPI_Session_init_f08(info,errhandler,session,ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Info, MPI_Errhandler
+   implicit none
+   TYPE(MPI_Info), INTENT(IN) :: info
+   TYPE(MPI_Errhandler), INTENT(OUT) :: errhandler
+   TYPE(MPI_Session), INTENT(OUT) :: session
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Session_init_f08
+end interface  PMPI_Session_init
+
+interface  PMPI_Session_finalize
+subroutine PMPI_Session_finalize_f08(session,ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   implicit none
+   TYPE(MPI_Session), INTENT(INOUT) :: session
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+end subroutine PMPI_Session_finalize_f08
+end interface  PMPI_Session_finalize
 
 interface  PMPI_Ssend
 subroutine PMPI_Ssend_f08(buf,count,datatype,dest,tag,comm,ierror)

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pcomm_create_from_group_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pcomm_create_from_group_f08.F90
@@ -1,0 +1,29 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine PMPI_Comm_create_from_group_f08(group, stringtag, info, errhandler, newcomm, ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Group, MPI_Errhandler, MPI_Info, MPI_Comm
+   use :: ompi_mpifh_bindings, only : ompi_comm_create_from_group_f
+   implicit none
+   TYPE(MPI_Group), INTENT(IN) :: group
+   CHARACTER(LEN=*), INTENT(IN) :: stringtag
+   TYPE(MPI_Info), INTENT(IN) :: info
+   TYPE(MPI_Errhandler), INTENT(IN) :: errhandler
+   TYPE(MPI_Comm), INTENT(OUT) :: newcomm
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_create_comm_from_group_f(group%MPI_VAL, stringtag, info%MPI_VAL, errhandler%MPI_VAL, &
+                                      newcomm%MPI_VAL, c_ierror, len(stringtag))
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Comm_create_from_group_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pgroup_from_session_pset_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pgroup_from_session_pset_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine PMPI_Group_from_session_pset_f08(session, pset_name, newgroup, ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Group
+   use :: ompi_mpifh_bindings, only : ompi_group_from_session_pset_f
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   CHARACTER(LEN=*), INTENT(IN) :: pset_name
+   TYPE(MPI_Group), INTENT(OUT) :: newgroup
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_group_from_session_pset_f(session%MPI_VAL, pset_name, newgroup%MPI_VAL, c_ierror, len(pset_name))
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Group_from_session_pset_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/profile/pintercomm_create_from_groups_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/pintercomm_create_from_groups_f08.F90
@@ -1,0 +1,35 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine PMPI_Intercomm_create_from_groups_f08(local_group, local_leader, remote_group, &
+                                                 remote_leader, stringtag, info, errhandler, &
+                                                 newintercomm, ierror)
+   use :: mpi_f08_types, only : MPI_Comm, MPI_Group, MPI_Errhandler, MPI_Info
+   use :: ompi_mpifh_bindings, only : ompi_intercomm_create_from_groups_f
+   implicit none
+   TYPE(MPI_Group), INTENT(IN) :: local_group, remote_group
+   INTEGER, INTENT(IN):: local_leader, remote_leader
+   CHARACTER(LEN=*), INTENT(IN) :: stringtag
+   TYPE(MPI_Info), INTENT(IN) :: info
+   TYPE(MPI_Errhandler), INTENT(IN) :: errhandler
+   TYPE(MPI_Comm), INTENT(OUT) :: newintercomm
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_create_intercomm_from_groups_f(local_group%MPI_VAL, local_leader, &
+                                            remote_group%MPI_VAL,  &
+                                            remote_leader, stringtag, info%MPI_VAL, &
+                                            errhandler%MPI_VAL, &
+                                            newintercomm%MPI_VAL, c_ierror, len(stringtag))
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Intercomm_create_from_groups_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/profile/psession_finalize_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/psession_finalize_f08.F90
@@ -1,0 +1,24 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine PMPI_Session_finalize_f08(session,ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   use :: ompi_mpifh_bindings, only : ompi_session_finalize_f
+   implicit none
+   TYPE(MPI_Session), INTENT(OUT) :: session
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_finalize_f(session%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Session_finalize_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/profile/psession_get_info_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/psession_get_info_f08.F90
@@ -1,0 +1,25 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine PMPI_Session_get_info_f08(session, info, ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Info
+   use :: ompi_mpifh_bindings, only : ompi_session_get_info_f
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   TYPE(MPI_Info), INTENT(OUT) :: info
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_get_info_f(session%MPI_VAL, info%MPI_VAL, c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Session_get_info_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/profile/psession_get_nth_pset_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/psession_get_nth_pset_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine PMPI_Session_get_nth_pset_f08(session, n, pset_len, pset_name, ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   use :: ompi_mpifh_bindings, only : ompi_session_get_nth_pset_f
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   INTEGER, OPTIONAL, INTENT(IN) :: n
+   INTEGER, OPTIONAL, INTENT(IN) :: pset_len
+   CHARACTER(LEN=*), INTENT(OUT) :: pset_name
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_get_nth_pset_f(session%MPI_VAL, n, pset_len, pset_name, c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Session_get_nth_pset_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/psession_get_nth_psetlen_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/psession_get_nth_psetlen_f08.F90
@@ -1,0 +1,25 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine PMPI_Session_get_nth_psetlen_f08(session, n, pset_len, ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   use :: ompi_mpifh_bindings, only : ompi_session_get_nth_psetlen_f
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   INTEGER, OPTIONAL, INTENT(IN) :: n
+   INTEGER, OPTIONAL, INTENT(OUT) :: pset_len
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_get_nth_psetlen_f(session%MPI_VAL, n, pset_len, c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Session_get_nth_psetlen_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/psession_get_num_psets_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/psession_get_num_psets_f08.F90
@@ -1,0 +1,24 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine PMPI_Session_get_num_psets_f08(session, npset_names, ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   use :: ompi_mpifh_bindings, only : ompi_session_get_num_psets_f
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   INTEGER, OPTIONAL, INTENT(OUT) :: npset_names
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_get_num_psets_f(session%MPI_VAL, npset_names, c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Session_get_num_psets_f08

--- a/ompi/mpi/fortran/use-mpi-f08/profile/psession_get_pset_info_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/psession_get_pset_info_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine PMPI_Session_get_pset_info_f08(session, pset_name, info, ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Info
+   use :: ompi_mpifh_bindings, only : ompi_session_get_pset_info_f
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   CHARACTER(LEN=*), INTENT(IN) :: pset_name
+   TYPE(MPI_Info), INTENT(OUT) :: info
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_get_pset_info_f(session%MPI_VAL, pset_name, info%MPI_VAL, c_ierror, len(pset_name))
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Session_get_pset_info_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/profile/psession_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/profile/psession_init_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine PMPI_Session_init_f08(info,errhandler,session,ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Info, MPI_Errhandler
+   use :: ompi_mpifh_bindings, only : ompi_session_init_f
+   implicit none
+   TYPE(MPI_Info), INTENT(IN) :: info
+   TYPE(MPI_Errhandler), INTENT(OUT) :: errhandler
+   TYPE(MPI_Session), INTENT(OUT) :: session
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_init_f(info%MPI_VAL,errhandler%MPI_VAL,session%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine PMPI_Session_init_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/session_finalize_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_finalize_f08.F90
@@ -1,0 +1,24 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine MPI_Session_finalize_f08(session,ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   use :: ompi_mpifh_bindings, only : ompi_session_finalize_f
+   implicit none
+   TYPE(MPI_Session), INTENT(OUT) :: session
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_finalize_f(session%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Session_finalize_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/session_get_info_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_get_info_f08.F90
@@ -1,0 +1,25 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine MPI_Session_get_info_f08(session, info, ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Info
+   use :: ompi_mpifh_bindings, only : ompi_session_get_info_f
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   TYPE(MPI_Info), INTENT(OUT) :: info
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_get_info_f(session%MPI_VAL, info%MPI_VAL, c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Session_get_info_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/session_get_nth_pset_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_get_nth_pset_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine MPI_Session_get_nth_pset_f08(session, n, pset_len, pset_name, ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   use :: ompi_mpifh_bindings, only : ompi_session_get_nth_pset_f
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   INTEGER, OPTIONAL, INTENT(IN) :: n
+   INTEGER, OPTIONAL, INTENT(IN) :: pset_len
+   CHARACTER(LEN=*), INTENT(OUT) :: pset_name
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_get_nth_pset_f(session%MPI_VAL, n, pset_len, pset_name, c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Session_get_nth_pset_f08

--- a/ompi/mpi/fortran/use-mpi-f08/session_get_nth_psetlen_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_get_nth_psetlen_f08.F90
@@ -1,0 +1,25 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine MPI_Session_get_nth_psetlen_f08(session, n, pset_len, ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   use :: ompi_mpifh_bindings, only : ompi_session_get_nth_psetlen_f
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   INTEGER, OPTIONAL, INTENT(IN) :: n
+   INTEGER, OPTIONAL, INTENT(OUT) :: pset_len
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_get_nth_psetlen_f(session%MPI_VAL, n, pset_len, c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Session_get_nth_psetlen_f08

--- a/ompi/mpi/fortran/use-mpi-f08/session_get_num_psets_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_get_num_psets_f08.F90
@@ -1,0 +1,24 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine MPI_Session_get_num_psets_f08(session, npset_names, ierror)
+   use :: mpi_f08_types, only : MPI_Session
+   use :: ompi_mpifh_bindings, only : ompi_session_get_num_psets_f
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   INTEGER, OPTIONAL, INTENT(OUT) :: npset_names
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_get_num_psets_f(session%MPI_VAL, npset_names, c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Session_get_num_psets_f08

--- a/ompi/mpi/fortran/use-mpi-f08/session_get_pset_info_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_get_pset_info_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine MPI_Session_get_pset_info_f08(session, pset_name, info, ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Info
+   use :: ompi_mpifh_bindings, only : ompi_session_get_pset_info_f
+   implicit none
+   TYPE(MPI_Session), INTENT(IN) :: session
+   CHARACTER(LEN=*), INTENT(IN) :: pset_name
+   TYPE(MPI_Info), INTENT(OUT) :: info
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_get_pset_info_f(session%MPI_VAL, pset_name, info%MPI_VAL, c_ierror, len(pset_name))
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Session_get_pset_info_f08
+

--- a/ompi/mpi/fortran/use-mpi-f08/session_init_f08.F90
+++ b/ompi/mpi/fortran/use-mpi-f08/session_init_f08.F90
@@ -1,0 +1,26 @@
+! -*- f90 -*-
+!
+! Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+! Copyright (c) 2009-2013 Los Alamos National Security, LLC.
+!                         All rights reserved.
+! Copyright (c) 2018      Research Organization for Information Science
+!                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
+! $COPYRIGHT$
+
+subroutine MPI_Session_init_f08(info,errhandler,session,ierror)
+   use :: mpi_f08_types, only : MPI_Session, MPI_Info, MPI_Errhandler
+   use :: ompi_mpifh_bindings, only : ompi_session_init_f
+   implicit none
+   TYPE(MPI_Info), INTENT(IN) :: info
+   TYPE(MPI_Errhandler), INTENT(OUT) :: errhandler
+   TYPE(MPI_Session), INTENT(OUT) :: session
+   INTEGER, OPTIONAL, INTENT(OUT) :: ierror
+   integer :: c_ierror
+
+   call ompi_session_init_f(info%MPI_VAL,errhandler%MPI_VAL,session%MPI_VAL,c_ierror)
+   if (present(ierror)) ierror = c_ierror
+
+end subroutine MPI_Session_init_f08
+

--- a/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h.in
+++ b/ompi/mpi/fortran/use-mpi-ignore-tkr/mpi-ignore-tkr-interfaces.h.in
@@ -11,6 +11,8 @@
 !                         reserved.
 ! Copyright (c) 2015-2018 Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
 ! $COPYRIGHT$
 !
 ! Additional copyrights may follow
@@ -1014,6 +1016,34 @@ subroutine PMPI_Comm_create_errhandler(function, errhandler, ierror)
   integer, intent(out) :: errhandler
   integer, intent(out) :: ierror
 end subroutine PMPI_Comm_create_errhandler
+
+end interface
+
+interface  MPI_Comm_create_from_group
+
+subroutine MPI_Comm_create_from_group(group, stringtag, info, errhandler, newcomm, ierror)
+   implicit none
+   integer, INTENT(IN) :: group
+   CHARACTER(LEN=*), INTENT(IN) :: stringtag
+   integer, INTENT(IN) :: info
+   integer, INTENT(IN) :: errhandler
+   integer, INTENT(OUT) :: newcomm
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine MPI_Comm_create_from_group
+
+end interface
+
+interface  PMPI_Comm_create_from_group
+
+subroutine PMPI_Comm_create_from_group(group, stringtag, info, errhandler, newcomm, ierror)
+   implicit none
+   integer, INTENT(IN) :: group
+   CHARACTER(LEN=*), INTENT(IN) :: stringtag
+   integer, INTENT(IN) :: info
+   integer, INTENT(IN) :: errhandler
+   integer, INTENT(OUT) :: newcomm
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine PMPI_Comm_create_from_group
 
 end interface
 
@@ -2714,6 +2744,31 @@ end subroutine PMPI_Group_free
 
 end interface
 
+interface MPI_Group_from_session_pset
+
+subroutine MPI_Group_from_session_pset(session, pset_name, newgroup, ierror)
+   implicit none
+   integer, INTENT(IN) :: session
+   CHARACTER(LEN=*), INTENT(IN) :: pset_name
+   integer, INTENT(OUT) :: newgroup
+   INTEGER, INTENT(OUT) :: ierror
+   integer :: c_ierror
+end subroutine MPI_Group_from_session_pset
+
+end interface
+
+interface PMPI_Group_from_session_pset
+
+subroutine PMPI_Group_from_session_pset(session, pset_name, newgroup, ierror)
+   implicit none
+   integer, INTENT(IN) :: session
+   CHARACTER(LEN=*), INTENT(IN) :: pset_name
+   integer, INTENT(OUT) :: newgroup
+   INTEGER, INTENT(OUT) :: ierror
+   integer :: c_ierror
+end subroutine PMPI_Group_from_session_pset
+
+end interface
 
 interface MPI_Group_incl
 
@@ -3913,6 +3968,41 @@ subroutine PMPI_Intercomm_create(local_comm, local_leader, bridge_comm, remote_l
 end subroutine PMPI_Intercomm_create
 
 end interface
+
+interface MPI_Intercomm_create_from_groups
+
+subroutine MPI_Intercomm_create_from_groups(local_group, local_leader, remote_group, &
+                                            remote_leader, stringtag, info, errhandler, &
+                                            newintercomm, ierror)
+   implicit none
+   integer, INTENT(IN) :: local_group, remote_group
+   integer, INTENT(IN):: local_leader, remote_leader
+   CHARACTER(LEN=*), INTENT(IN) :: stringtag
+   integer, INTENT(IN) :: info
+   integer, INTENT(IN) :: errhandler
+   integer, INTENT(OUT) :: newintercomm
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine MPI_Intercomm_create_from_groups
+
+end interface
+
+interface PMPI_Intercomm_create_from_groups
+
+subroutine PMPI_Intercomm_create_from_groups(local_group, local_leader, remote_group, &
+                                            remote_leader, stringtag, info, errhandler, &
+                                            newintercomm, ierror)
+   implicit none
+   integer, INTENT(IN) :: local_group, remote_group
+   integer, INTENT(IN):: local_leader, remote_leader
+   CHARACTER(LEN=*), INTENT(IN) :: stringtag
+   integer, INTENT(IN) :: info
+   integer, INTENT(IN) :: errhandler
+   integer, INTENT(OUT) :: newintercomm
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine PMPI_Intercomm_create_from_groups
+
+end interface
+
 
 
 interface MPI_Intercomm_merge
@@ -5794,6 +5884,125 @@ end subroutine PMPI_Sendrecv_replace
 
 end interface
 
+interface MPI_Session_get_info
+subroutine MPI_Session_get_info(session, info, ierror)
+   implicit none
+   integer, INTENT(IN) :: session
+   integer, INTENT(OUT) :: info
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine MPI_Session_get_info
+end interface
+
+interface PMPI_Session_get_info
+subroutine PMPI_Session_get_info(session, info, ierror)
+   implicit none
+   integer, INTENT(IN) :: session
+   integer, INTENT(OUT) :: info
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine PMPI_Session_get_info
+end interface
+
+interface MPI_Session_get_nth_pset
+subroutine MPI_Session_get_nth_pset(session, n, pset_len, pset_name, ierror)
+   implicit none
+   integer, INTENT(IN) :: session
+   INTEGER, OPTIONAL, INTENT(IN) :: n
+   INTEGER, OPTIONAL, INTENT(IN) :: pset_len
+   CHARACTER(LEN=*), INTENT(OUT) :: pset_name
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine MPI_Session_get_nth_pset
+end interface MPI_Session_get_nth_pset
+
+interface PMPI_Session_get_nth_pset
+subroutine PMPI_Session_get_nth_pset(session, n, pset_len, pset_name, ierror)
+   implicit none
+   integer, INTENT(IN) :: session
+   INTEGER, INTENT(IN) :: n
+   INTEGER, INTENT(IN) :: pset_len
+   CHARACTER(LEN=*), INTENT(OUT) :: pset_name
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine PMPI_Session_get_nth_pset
+end interface PMPI_Session_get_nth_pset
+
+interface MPI_Session_get_nth_psetlen
+subroutine MPI_Session_get_nth_psetlen(session, n, pset_len, ierror)
+   implicit none
+   integer, INTENT(IN) :: session
+   INTEGER, INTENT(IN) :: n
+   INTEGER, INTENT(OUT) :: pset_len
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine MPI_Session_get_nth_psetlen
+end interface 
+
+interface PMPI_Session_get_nth_psetlen
+subroutine PMPI_Session_get_nth_psetlen(session, n, pset_len, ierror)
+   implicit none
+   integer, INTENT(IN) :: session
+   INTEGER, INTENT(IN) :: n
+   INTEGER, INTENT(OUT) :: pset_len
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine PMPI_Session_get_nth_psetlen
+end interface
+
+interface MPI_Session_get_pset_info
+subroutine MPI_Session_get_pset_info(session, pset_name, info, ierror)
+   implicit none
+   integer, INTENT(IN) :: session
+   CHARACTER(LEN=*), INTENT(IN) :: pset_name
+   integer, INTENT(OUT) :: info
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine MPI_Session_get_pset_info
+end interface
+
+interface PMPI_Session_get_pset_info
+subroutine PMPI_Session_get_pset_info(session, pset_name, info, ierror)
+   implicit none
+   integer, INTENT(IN) :: session
+   CHARACTER(LEN=*), INTENT(IN) :: pset_name
+   integer, INTENT(OUT) :: info
+   INTEGER, INTENT(OUT) :: ierror
+end subroutine PMPI_Session_get_pset_info
+end interface
+
+interface  MPI_Session_init
+subroutine MPI_Session_init(info,errhandler,session,ierror)
+   implicit none
+   integer, intent(in) :: info
+   integer, intent(OUT) :: errhandler
+   integer, intent(OUT) :: session
+   integer, intent(OUT) :: ierror
+end subroutine MPI_Session_init
+end interface
+
+interface  PMPI_Session_init
+subroutine PMPI_Session_init(info,errhandler,session,ierror)
+   implicit none
+   integer, intent(in) :: info
+   integer, intent(OUT) :: errhandler
+   integer, intent(OUT) :: session
+   integer, intent(OUT) :: ierror
+end subroutine PMPI_Session_init
+end interface
+
+interface  MPI_Session_finalize
+
+subroutine MPI_Session_finalize(session,ierror)
+   implicit none
+   integer, intent(inout) :: session
+   integer, intent(OUT) :: ierror
+end subroutine MPI_Session_finalize
+
+end interface  MPI_Session_finalize
+
+interface  PMPI_Session_finalize
+
+subroutine PMPI_Session_finalize(session,ierror)
+   implicit none
+   integer, intent(inout) :: session
+   integer, intent(OUT) :: ierror
+end subroutine PMPI_Session_finalize
+
+end interface  PMPI_Session_finalize
 
 interface MPI_Ssend
 

--- a/ompi/mpi/fortran/use-mpi-tkr/mpi-f90-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-tkr/mpi-f90-interfaces.h
@@ -13,6 +13,8 @@
 ! Copyright (c) 2006-2014 Cisco Systems, Inc.  All rights reserved.
 ! Copyright (c) 2016-2018 Research Organization for Information Science
 !                         and Technology (RIST).  All rights reserved.
+! Copyright (c) 2019      Triad National Security, LLC. All rights
+!                         reserved.
 ! $COPYRIGHT$
 !
 ! Additional copyrights may follow
@@ -277,6 +279,19 @@ end subroutine MPI_Comm_create
 
 end interface
 
+interface  MPI_Comm_create_from_group
+
+subroutine MPI_Comm_create_from_group(group, stringtag, info, errhandler, newcomm, ierror)
+   implicit none
+   integer, intent(in) :: group
+   character(len=*), intent(in) :: stringtag
+   integer, intent(in) :: info
+   integer, intent(in) :: errhandler
+   integer, intent(out) :: newcomm
+   integer, intent(out) :: ierror
+end subroutine MPI_Comm_create_from_group
+
+end interface
 
 interface MPI_Comm_create_group
 
@@ -837,6 +852,16 @@ end subroutine MPI_Group_free
 
 end interface
 
+interface MPI_Group_from_session_pset
+subroutine MPI_Group_from_session_pset(session, pset_name, newgroup, ierror)
+   implicit none
+   integer, intent(in) :: session
+   character(len=*), intent(in) :: pset_name
+   integer, intent(out) :: newgroup
+   integer, intent(out) :: ierror
+end subroutine MPI_Group_from_session_pset
+end interface
+
 
 interface MPI_Group_incl
 
@@ -1088,6 +1113,22 @@ end subroutine MPI_Intercomm_create
 
 end interface
 
+interface MPI_Intercomm_create_from_groups
+
+subroutine MPI_Intercomm_create_from_groups(local_group, local_leader, remote_group, remote_leader,
+                                          stringtag, info, errhandler, newintercomm, ierror)
+   implicit none
+   integer, intent(in) :: local_group, remote_group
+   integer, intent(in):: local_leader, remote_leader
+   character(len=*), intent(in) :: stringtag
+   integer, intent(in) :: info
+   integer, intent(in) :: errhandler
+   integer, intent(out) :: newintercomm
+   integer, intent(out) :: ierror
+end subroutine MPI_Intercomm_create_from_groups_f08
+
+end interface
+
 
 interface MPI_Intercomm_merge
 
@@ -1259,6 +1300,80 @@ end subroutine MPI_Request_get_status
 
 end interface
 
+nterface MPI_Session_get_info
+subroutine MPI_Session_get_info(session, info, ierror)
+   implicit none
+   integer, intent(in) :: session
+   integer, intent(out) :: info_used
+   integer, intent(out) :: ierror
+end subroutine MPI_Session_get_info
+end interface
+
+interface MPI_Session_get_nth_pset
+subroutine MPI_Session_get_nth_pset(session, n, pset_len, pset_name, ierror)
+   implicit none
+   integer, intent(in) :: session
+   integer, OPTIONAL, intent(in) :: n
+   integer, OPTIONAL, intent(in) :: pset_len
+   character(len=*), intent(out) :: pset_name
+   integer, intent(out) :: ierror
+end subroutine MPI_Session_get_nth_pset
+end interface
+
+interface MPI_Session_get_nth_psetlen
+subroutine MPI_Session_get_nth_psetlen(session, n, pset_len, ierror)
+   implicit none
+   integer, intent(in) :: session
+   integer, intent(in) :: n
+   integer, intent(out) :: pset_len
+   integer, intent(out) :: ierror
+end subroutine MPI_Session_get_nth_psetlen
+end interface
+
+
+interface MPI_Session_get_num_psets
+
+subroutine MPI_Session_get_num_psets(session, npset_names, ierror)
+   implicit none
+   integer, intent(in) :: session
+   integer, intent(out) :: npset_names
+   integer, intent(out) :: ierror
+end subroutine MPI_Session_get_num_psets
+
+end interface  MPI_Session_get_num_psets
+
+interface MPI_Session_get_pset_info
+subroutine MPI_Session_get_pset_info(session, pset_name, info, ierror)
+   implicit none
+   integer, intent(in) :: session
+   character(len=*), intent(in) :: pset_name
+   integer, intent(out) :: info
+   integer, intent(out) :: ierror
+end subroutine MPI_Session_get_pset_info
+end interface
+
+
+interface  MPI_Session_init
+
+subroutine MPI_Session_init(info,errhandler,session,ierror)
+   implicit none
+   integer, intent(in) :: info
+   integer, intent(OUT) :: errhandler
+   integer, intent(OUT) :: session
+   integer, intent(OUT) :: ierror
+end subroutine MPI_Session_init
+
+end interface  MPI_Session_init
+
+interface  MPI_Session_finalize
+
+subroutine MPI_Session_finalize(session,ierror)
+   implicit none
+   integer, intent(inout) :: session
+   integer, intent(OUT) :: ierror
+end subroutine MPI_Session_finalize
+
+end interface  MPI_Session_finalize
 
 interface MPI_Start
 

--- a/ompi/mpi/fortran/use-mpi-tkr/pmpi-f90-interfaces.h
+++ b/ompi/mpi/fortran/use-mpi-tkr/pmpi-f90-interfaces.h
@@ -277,6 +277,17 @@ end subroutine PMPI_Comm_create
 
 end interface
 
+interface  PMPI_Comm_create_from_group
+subroutine PMPI_Comm_create_from_group(group, stringtag, info, errhandler, newcomm, ierror)
+   implicit none
+   integer, intent(in) :: group
+   character(len=*), intent(in) :: stringtag
+   integer, intent(in) :: info
+   integer, intent(in) :: errhandler
+   integer, intent(out) :: newcomm
+   integer, intent(out) :: ierror
+end subroutine PMPI_Comm_create_from_group
+end interface
 
 interface PMPI_Comm_create_group
 
@@ -837,6 +848,15 @@ end subroutine PMPI_Group_free
 
 end interface
 
+interface PMPI_Group_from_session_pset
+subroutine PMPI_Group_from_session_pset(session, pset_name, newgroup, ierror)
+   implicit none
+   integer, intent(in) :: session
+   character(len=*), intent(in) :: pset_name
+   integer, intent(out) :: newgroup
+   integer, intent(out) :: ierror
+end subroutine PMPI_Group_from_session_pset
+end interface
 
 interface PMPI_Group_incl
 
@@ -1088,6 +1108,22 @@ end subroutine PMPI_Intercomm_create
 
 end interface
 
+interface PMPI_Intercomm_create_from_groups
+
+subroutine PMPI_Intercomm_create_from_groups(local_group, local_leader, remote_group, remote_leader,
+                                          stringtag, info, errhandler, newintercomm, ierror)
+   implicit none
+   integer, intent(in) :: local_group, remote_group
+   integer, intent(in):: local_leader, remote_leader
+   character(len=*), intent(in) :: stringtag
+   integer, intent(in) :: info
+   integer, intent(in) :: errhandler
+   integer, intent(out) :: newintercomm
+   integer, intent(out) :: ierror
+end subroutine PMPI_Intercomm_create_from_groups_f08
+
+end interface
+
 
 interface PMPI_Intercomm_merge
 
@@ -1259,6 +1295,80 @@ end subroutine PMPI_Request_get_status
 
 end interface
 
+nterface PMPI_Session_get_info
+subroutine PMPI_Session_get_info(session, info, ierror)
+   implicit none
+   integer, intent(in) :: session
+   integer, intent(out) :: info_used
+   integer, intent(out) :: ierror
+end subroutine PMPI_Session_get_info
+end interface
+
+interface PMPI_Session_get_nth_pset
+subroutine PMPI_Session_get_nth_pset(session, n, pset_len, pset_name, ierror)
+   implicit none
+   integer, intent(in) :: session
+   integer, intent(in) :: n
+   integer, intent(in) :: pset_len
+   character(len=*), intent(out) :: pset_name
+   integer, intent(out) :: ierror
+end subroutine PMPI_Session_get_nth_pset
+end interface 
+
+interface PMPI_Session_get_nth_psetlen
+subroutine PMPI_Session_get_nth_psetlen(session, n, pset_len, ierror)
+   implicit none
+   integer, intent(in) :: session
+   integer, intent(in) :: n
+   integer, intent(out) :: pset_len
+   integer, intent(out) :: ierror
+end subroutine PMPI_Session_get_nth_psetlen
+end interface
+
+
+interface PMPI_Session_get_num_psets
+
+subroutine PMPI_Session_get_num_psets(session, npset_names, ierror)
+   implicit none
+   integer, intent(in) :: session
+   integer, intent(out) :: npset_names
+   integer, intent(out) :: ierror
+end subroutine PMPI_Session_get_num_psets
+
+end interface
+
+interface PMPI_Session_get_pset_info
+subroutine PMPI_Session_get_pset_info(session, pset_name, info, ierror)
+   implicit none
+   integer, intent(in) :: session
+   character(len=*), intent(in) :: pset_name
+   integer, intent(out) :: info
+   integer, intent(out) :: ierror
+end subroutine PMPI_Session_get_pset_info
+end interface 
+
+
+interface  PMPI_Session_init
+
+subroutine PMPI_Session_init(info,errhandler,session,ierror)
+   implicit none
+   integer, intent(in) :: info
+   integer, intent(OUT) :: errhandler
+   integer, intent(OUT) :: session
+   integer, intent(OUT) :: ierror
+end subroutine PMPI_Session_init
+
+end interface
+
+interface  PMPI_Session_finalize
+
+subroutine PMPI_Session_finalize(session,ierror)
+   implicit none
+   integer, intent(inout) :: session
+   integer, intent(OUT) :: ierror
+end subroutine PMPI_Session_finalize
+
+end interface
 
 interface PMPI_Start
 


### PR DESCRIPTION
add fortran session_get_nth_pset
add get_info method
add get_pset_info
add group_from_session_pset
add comm_from_group
add intercomm_create_from_groups
add MPI_MAX_FROM_GROUP_TAG
add remaining fortran interfaces

also add a few missing constants

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>