### PR TITLE
sessions: add in missing unlock

### DIFF
--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -635,6 +635,7 @@ int ompi_mpi_instance_init (int ts_level,  opal_info_t *info, ompi_errhandler_t 
     }
 
     *instance = new_instance;
+    opal_mutex_unlock (&instance_lock);
 
     return OMPI_SUCCESS;
 }


### PR DESCRIPTION
not sure how this was working before.  But without this lock the
DASK-MPI demo just hung

Signed-off-by: Howard Pritchard <howardp@lanl.gov>