### PR TITLE
sessions: refactor way attr subsys is setup

### DIFF
--- a/ompi/attribute/attribute.h
+++ b/ompi/attribute/attribute.h
@@ -13,9 +13,9 @@
  * Copyright (c) 2007      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
  *                         reserved.
-  * $COPYRIGHT$
+ * $COPYRIGHT$
  *
  * Additional copyrights may follow
  *
@@ -206,13 +206,23 @@ int ompi_attr_hash_init(opal_hash_table_t **hash)
 }
 
 /**
- * Initialize the main attribute hash that stores the keyvals and meta data
+ * Increase the reference count on the attributes subsystem.  Instantiate subsys if
+ * not yet instantiated.
  *
  * @return OMPI return code
  */
 
-int ompi_attr_init(void);
+int ompi_attr_get_ref(void);
 
+
+/**
+ * Decrease the reference count on the attributes subsystem.  Attributes subsystem
+ * resources are released when the count drops to zero.
+ *
+ * @return OMPI return code
+ */
+
+int ompi_attr_put_ref(void);
 
 /**
  * Create a new key for use by attribute of Comm/Win/Datatype/Instance

--- a/ompi/communicator/comm_init.c
+++ b/ompi/communicator/comm_init.c
@@ -168,6 +168,9 @@ int ompi_comm_init(void)
     /* initialize communicator requests (for ompi_comm_idup) */
     ompi_comm_request_init ();
 
+    /* get a reference on the attributes subsys */
+    ompi_attr_get_ref();
+
     ompi_mpi_instance_append_finalize (ompi_comm_finalize);
 
     return OMPI_SUCCESS;
@@ -269,6 +272,11 @@ int ompi_comm_init_mpi3 (void)
        MPI_COMM_SELF, the keyhash will automatically be created. */
     ompi_mpi_comm_self.comm.c_keyhash = NULL;
 
+    /*
+     * finally here we set the predefined attribute keyvals
+     */
+    ompi_attr_create_predefined();
+
     OBJ_RETAIN(&ompi_mpi_errors_are_fatal.eh);
 
     return OMPI_SUCCESS;
@@ -303,7 +311,7 @@ ompi_communicator_t *ompi_comm_allocate ( int local_size, int remote_size )
 
 static int ompi_comm_finalize (void)
 {
-    int max, i;
+    int max, i, ret = OMPI_SUCCESS;
     ompi_communicator_t *comm;
 
     /* disconnect all dynamic communicators */
@@ -396,7 +404,10 @@ static int ompi_comm_finalize (void)
     /* finalize communicator requests */
     ompi_comm_request_fini ();
 
-    return OMPI_SUCCESS;
+    /* release a reference to the attributes subsys */
+    ret = ompi_attr_put_ref();
+
+    return ret;
 }
 
 /********************************************************************************/

--- a/ompi/datatype/ompi_datatype_module.c
+++ b/ompi/datatype/ompi_datatype_module.c
@@ -39,6 +39,7 @@
 #include "ompi/datatype/ompi_datatype.h"
 #include "ompi/datatype/ompi_datatype_internal.h"
 #include "ompi/instance/instance.h"
+#include "ompi/attribute/attribute.h"
 
 #include "mpi.h"
 
@@ -475,6 +476,7 @@ opal_pointer_array_t ompi_datatype_f_to_c_table = {{0}};
 int32_t ompi_datatype_init( void )
 {
     int32_t i;
+    int ret = OMPI_SUCCESS;
 
     opal_datatype_init();
 
@@ -668,6 +670,13 @@ int32_t ompi_datatype_init( void )
         }
     }
     ompi_datatype_default_convertors_init();
+
+    /* get a reference to the attributes subsys */
+    ret = ompi_attr_get_ref();
+    if (OMPI_SUCCESS != ret) {
+        return ret;
+    }
+
     ompi_mpi_instance_append_finalize (ompi_datatype_finalize);
     return OMPI_SUCCESS;
 }
@@ -675,6 +684,8 @@ int32_t ompi_datatype_init( void )
 
 static int ompi_datatype_finalize (void)
 {
+    int ret = OMPI_SUCCESS;
+
     /* As the synonyms are just copies of the internal data we should not free them.
      * Anyway they are over the limit of OMPI_DATATYPE_MPI_MAX_PREDEFINED so they will never get freed.
      */
@@ -696,7 +707,10 @@ static int ompi_datatype_finalize (void)
     /* don't call opal_datatype_finalize () as it no longer exists. the function will be called
      * opal_finalize_util (). */
 
-    return OMPI_SUCCESS;
+    /* release a reference to the attributes subsys */
+    ret = ompi_attr_put_ref();
+
+    return ret;
 }
 
 

--- a/ompi/instance/instance.c
+++ b/ompi/instance/instance.c
@@ -476,11 +476,6 @@ static int ompi_mpi_instance_init_common (void)
         return ompi_instance_print_error ("ompi_win_init() failed", ret);
     }
 
-    /* initialize attribute meta-data structure for comm/win/dtype */
-    if (OMPI_SUCCESS != (ret = ompi_attr_init ())) {
-        return ompi_instance_print_error ("ompi_attr_init() failed", ret);
-    }
-
     /* Setup the dynamic process management (DPM) subsystem */
     if (OMPI_SUCCESS != (ret = ompi_dpm_init ())) {
         return ompi_instance_print_error ("ompi_dpm_init() failed", ret);

--- a/ompi/win/win.c
+++ b/ompi/win/win.c
@@ -17,7 +17,7 @@
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016-2017 IBM Corporation. All rights reserved.
- * Copyright (c) 2018      Triad National Security, LLC. All rights
+ * Copyright (c) 2018-2019 Triad National Security, LLC. All rights
  *                         reserved.
  * $COPYRIGHT$
  *
@@ -86,6 +86,8 @@ static void ompi_win_dump (ompi_win_t *win)
 
 static int ompi_win_finalize(void)
 {
+    int ret = OMPI_SUCCESS;
+
     size_t size = opal_pointer_array_get_size (&ompi_mpi_windows);
     /* start at 1 to skip win null */
     for (size_t i = 1 ; i < size ; ++i) {
@@ -105,7 +107,10 @@ static int ompi_win_finalize(void)
     OBJ_RELEASE(ompi_win_accumulate_ops);
     OBJ_RELEASE(ompi_win_accumulate_order);
 
-    return OMPI_SUCCESS;
+    /* release a reference to the attributes subsys */
+    ret = ompi_attr_put_ref();
+
+    return ret;
 }
 
 int ompi_win_init (void)
@@ -136,6 +141,12 @@ int ompi_win_init (void)
 
     ret = mca_base_var_enum_create_flag ("accumulate_order", accumulate_order_flags, &ompi_win_accumulate_order);
     if (OPAL_SUCCESS != ret) {
+        return ret;
+    }
+
+    /* get a reference to the attributes subsys */
+    ret = ompi_attr_get_ref();
+    if (OMPI_SUCCESS != ret) {
         return ret;
     }
 


### PR DESCRIPTION
The win, datatype, and comm subsystems are dependent on
the attr subsys in a way that prevents a simple uncoordinated
tear down of the attr subsys.  Refactor the way attr subsys
is initialized to be based on when consumers of its functionality
are instantiated.

The handling of the predefined keyvals had to be moved out and
invoked separately as part of the creation of ompi_mpi_comm_world.

Fixes #18

Signed-off-by: Howard Pritchard <howardp@lanl.gov>